### PR TITLE
[fix] misc bug fixes and documentation improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+tests/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ This is the onboard code for Project Instinct. Dsgiend for supporting the infere
 
 - Install `unitree_hg` and `unitree_go` message definitions
 
+    Clone and build [unitree_ros2](https://github.com/unitreerobotics/unitree_ros2) following its README, then source the workspace:
+    ```bash
+    source {PATH_TO_UNITREE_ROS2}/cyclonedds_ws/install/setup.bash
+    ```
+    This makes `unitree_hg` and `unitree_go` available to Python.
+
 
 ### Installation (Common)
 

--- a/instinct_onboard/agents/__init__.py
+++ b/instinct_onboard/agents/__init__.py
@@ -1,0 +1,34 @@
+"""instinct_onboard agents module.
+
+This module provides various agent implementations for robot control:
+- OnboardAgent: Base class for onboard agents
+- ColdStartAgent: Agent for safe joint initialization
+- ParkourAgent: Agent for parkour tasks with depth perception
+- ParkourStandAgent: Agent for standing/balancing
+- TrackerAgent: Agent for motion tracking from NPZ files
+- PerceptiveTrackerAgent: TrackerAgent with depth perception
+- ShadowingAgent: Agent for ROS topic-based motion reference
+- WalkAgent: Agent for basic walking
+- InteractionAgent: Agent for object interaction tasks
+"""
+
+from instinct_onboard.agents.base import ColdStartAgent, OnboardAgent
+from instinct_onboard.agents.interaction_agent import InteractionAgent, MotionData
+from instinct_onboard.agents.parkour_agent import ParkourAgent, ParkourStandAgent
+from instinct_onboard.agents.shadowing_agent import MotionAsActAgent, ShadowingAgent
+from instinct_onboard.agents.tracking_agent import PerceptiveTrackerAgent, TrackerAgent
+from instinct_onboard.agents.walk_agent import WalkAgent
+
+__all__ = [
+    "OnboardAgent",
+    "ColdStartAgent",
+    "ParkourAgent",
+    "ParkourStandAgent",
+    "TrackerAgent",
+    "PerceptiveTrackerAgent",
+    "ShadowingAgent",
+    "MotionAsActAgent",
+    "WalkAgent",
+    "InteractionAgent",
+    "MotionData",
+]

--- a/instinct_onboard/agents/base.py
+++ b/instinct_onboard/agents/base.py
@@ -143,7 +143,7 @@ class OnboardAgent(ABC):
         elif hasattr(self, f"_get_{command_name}_obs"):
             self.obs_funcs[obs_name] = getattr(self, f"_get_{command_name}_obs")
             print(
-                "Warning: '_get_{command_name}_obs' for command {command_name} shall be deprecated. Please implementing your command-related observation function '_get_{command_name}_cmd_obs' instead."
+                f"Warning: '_get_{command_name}_obs' for command {command_name} shall be deprecated. Please implementing your command-related observation function '_get_{command_name}_cmd_obs' instead."
             )
         else:
             raise ValueError(

--- a/instinct_onboard/agents/interaction_agent.py
+++ b/instinct_onboard/agents/interaction_agent.py
@@ -1,175 +1,48 @@
-"""
-InteractionAgent for instinct_onboard.
+"""Interaction deployment aligned with the sitting checkpoint truth.
 
-This agent combines:
-- Depth perception from ParkourAgent (0-depth_encoder.onnx)
-- Motion reference tracking from ShadowingAgent (0-motion_ref.onnx, forward_kinematics.onnx)
-- Object state observations (object_pos, object_ori, wrist_object_contact)
+`Instinct-Interaction-G1-v0` is deployed using the sitting checkpoint layout and
+observation contract. The onboard implementation therefore reuses the mature
+perceptive tracker pipeline:
 
-Reference:
-- ParkourAgent: depth image processing and velocity command
-- ShadowingAgent: motion reference encoding and FK
-- TrackerAgent: NPZ file loading pattern
+raw policy obs -> policy normalizer -> depth slice -> depth encoder -> actor
 """
 
 from __future__ import annotations
 
-import math
 import os
-from dataclasses import dataclass
-from typing import Callable, Dict, Optional
 
-import cv2
-import numpy as np
-import onnxruntime as ort
-import prettytable
-import quaternion
-import ros2_numpy as rnp
-import yaml
-from geometry_msgs.msg import TransformStamped
-from sensor_msgs.msg import Image, PointCloud2, PointField
-
-from instinct_onboard.agents.base import ColdStartAgent, OnboardAgent
-from instinct_onboard.normalizer import Normalizer
+from instinct_onboard.agents.tracking_agent import MotionData, PerceptiveTrackerAgent
 from instinct_onboard.ros_nodes.base import RealNode
-from instinct_onboard.utils import (
-    CircularBuffer,
-    inv_quat,
-    quat_rotate_inverse,
-    quat_slerp_batch,
-    quat_to_tan_norm_batch,
-    yaw_quat,
-)
 
 
-@dataclass
-class MotionData:
-    """Motion data structure for interaction task.
-    
-    Compared to TrackerAgent's MotionData, this adds object_data field
-    for object state trajectories.
-    """
-    framerate: float
-    # Joint orders must match the robot joint names in simulation order.
-    joint_pos: np.ndarray  # (N, num_joints)
-    joint_vel: np.ndarray  # (N, num_joints)
-    base_pos: np.ndarray   # (N, 3)
-    base_quat: np.ndarray   # (N, 4)
-    total_num_frames: int
-    # Object data - stored as dict for flexibility
-    # Expected keys: "box" -> {pos, quat, lin_vel, ang_vel, contact, validity}
-    object_data: Optional[Dict[str, np.ndarray]] = None
+class InteractionAgent(PerceptiveTrackerAgent):
+    """Thin interaction wrapper over the sitting-compatible perceptive tracker."""
 
-
-def load_motion_data(
-    motion_file: str,
-    robot_joint_names: list[str],
-    target_framerate: float,
-) -> MotionData:
-    """Load motion data from NPZ file, compatible with interaction task.
-    
-    Handles both standard motion data and motion data with object trajectories.
-    """
-    motion_data = np.load(motion_file, allow_pickle=True)
-    framerate = motion_data["framerate"].item()
-
-    motion_joint_names_all = motion_data["joint_names"].tolist()
-    motion_joint_to_robot_joint_ids = [motion_joint_names_all.index(j_name) for j_name in robot_joint_names]
-
-    joint_pos = motion_data["joint_pos"][:, motion_joint_to_robot_joint_ids]
-    joint_pos_ = np.concatenate([joint_pos[0:1], joint_pos])
-    joint_vel = (joint_pos_[1:] - joint_pos_[:-1]) * framerate
-    base_pos = motion_data["base_pos_w"]
-    base_quat = motion_data["base_quat_w"]
-    total_num_frames = motion_data["joint_pos"].shape[0]
-
-    # Try to load object data if available
-    object_data = None
-    if "object_data" in motion_data.files:
-        object_data = motion_data["object_data"].item()  # Convert from numpy dict to python dict
-
-    motion = MotionData(
-        framerate=framerate,
-        joint_pos=joint_pos,
-        joint_vel=joint_vel,
-        base_pos=base_pos,
-        base_quat=base_quat,
-        total_num_frames=total_num_frames,
-        object_data=object_data,
+    REQUIRED_FILES = (
+        ("params", "env.yaml"),
+        ("params", "agent.yaml"),
+        ("exported", "actor.onnx"),
+        ("exported", "0-depth_image.onnx"),
+        ("exported", "policy_normalizer.npz"),
     )
-
-    return match_framerate(motion, target_framerate)
-
-
-def match_framerate(motion_data: MotionData, target_framerate: float) -> MotionData:
-    """Resample motion data to target framerate."""
-    if motion_data.framerate == target_framerate:
-        return motion_data
-
-    motion_length_s = motion_data.total_num_frames / motion_data.framerate
-    new_total_num_frames = math.floor(motion_length_s * target_framerate)
-    new_frame_idxs = np.linspace(0, motion_data.total_num_frames - 1, new_total_num_frames)
-    floor = np.floor(new_frame_idxs).astype(int)
-    ceil = np.ceil(new_frame_idxs).astype(int)
-    frac = new_frame_idxs - floor
-
-    new_joint_pos = (1 - frac)[:, None] * motion_data.joint_pos[floor] + frac[:, None] * motion_data.joint_pos[ceil]
-    joint_pos_ = np.concatenate([new_joint_pos[0:1], new_joint_pos])
-    new_joint_vel = (joint_pos_[1:] - joint_pos_[:-1]) * target_framerate
-    new_base_pos = (1 - frac)[:, None] * motion_data.base_pos[floor] + frac[:, None] * motion_data.base_pos[ceil]
-    new_base_quat = quat_slerp_batch(motion_data.base_quat[floor], motion_data.base_quat[ceil], frac)
-
-    # Resample object data if available
-    new_object_data = None
-    if motion_data.object_data is not None:
-        new_object_data = {}
-        for obj_name, obj_arrays in motion_data.object_data.items():
-            if isinstance(obj_arrays, dict):
-                # Object state dict with pos, quat, lin_vel, ang_vel, contact, validity
-                new_object_data[obj_name] = {
-                    key: (1 - frac)[:, None] * val[floor] + frac[:, None] * val[ceil]
-                    if val.ndim == 2 and val.shape[0] == motion_data.total_num_frames
-                    else val
-                    for key, val in obj_arrays.items()
-                }
-            else:
-                # Simple array
-                new_object_data[obj_name] = (
-                    (1 - frac)[:, None] * obj_arrays[floor] + frac[:, None] * obj_arrays[ceil]
-                )
-
-    return MotionData(
-        framerate=target_framerate,
-        joint_pos=new_joint_pos.astype(np.float32),
-        joint_vel=new_joint_vel.astype(np.float32),
-        base_pos=new_base_pos.astype(np.float32),
-        base_quat=new_base_quat.astype(np.float32),
-        total_num_frames=new_total_num_frames,
-        object_data=new_object_data,
-    )
-
-
-class InteractionAgent(OnboardAgent):
-    """Agent for interaction tasks combining depth perception, motion reference, and object state.
-    
-    This agent loads:
-    - actor.onnx: Policy network
-    - 0-depth_encoder.onnx: Depth image encoder
-    - 0-motion_ref.onnx: Motion reference encoder (optional)
-    - forward_kinematics.onnx: FK for link positions
-    
-    Observations include:
-    - Proprioception: joint_pos, joint_vel, projected_gravity, base_ang_vel, last_action
-    - Depth: depth_latent (from depth encoder)
-    - Motion reference: joint_pos_ref, joint_vel_ref, position_ref, rotation_ref
-    - Object state: object_pos, object_ori (relative to base frame)
-    - Contact: wrist_object_contact
-    
-    Since motion data is not yet available, object-related observations return zeros.
-    """
-
-    rs_resolution = (480, 270)
-    rs_frequency = 60
+    EXPECTED_POLICY_OBS = [
+        "joint_pos_ref",
+        "joint_vel_ref",
+        "position_ref",
+        "rotation_ref",
+        "projected_gravity",
+        "base_ang_vel",
+        "joint_pos",
+        "joint_vel",
+        "last_action",
+        "depth_image",
+    ]
+    EXPECTED_RAW_OBS_DIM = 1339
+    EXPECTED_DEPTH_DIM = 18 * 32
+    EXPECTED_DEPTH_IMAGE_RESOLUTION = (18, 32)
+    EXPECTED_DEPTH_ENCODER_INPUT_SHAPE = [1, 1, 18, 32]
+    EXPECTED_DEPTH_ENCODER_OUTPUT_DIM = 32
+    EXPECTED_ACTOR_INPUT_DIM = 795
 
     def __init__(
         self,
@@ -179,742 +52,84 @@ class InteractionAgent(OnboardAgent):
         depth_vis: bool = True,
         pointcloud_vis: bool = True,
         target_motion_framerate: float = 50.0,
-        object_name: str = "box",
     ):
-        super().__init__(logdir, ros_node)
-        self.target_motion_framerate = target_motion_framerate
-        self.object_name = object_name
-        self.ort_sessions: dict[str, ort.InferenceSession] = dict()
-        self._parse_obs_config()
-        self._parse_action_config()
-        self._load_models()
-        self._load_all_motions(motion_file_dir)
-        
-        # Depth visualization
-        self.depth_vis = depth_vis
-        if self.depth_vis:
-            self.debug_depth_publisher = ros_node.create_publisher(Image, "/debug/depth_image", 10)
-        else:
-            self.debug_depth_publisher = None
-        
-        self.pointcloud_vis = pointcloud_vis
-        if self.pointcloud_vis:
-            self.debug_pointcloud_publisher = ros_node.create_publisher(PointCloud2, "/debug/pointcloud", 10)
-        else:
-            self.debug_pointcloud_publisher = None
+        self._validate_checkpoint_layout(logdir)
+        super().__init__(
+            logdir=logdir,
+            motion_file_dir=motion_file_dir,
+            ros_node=ros_node,
+            target_motion_framerate=target_motion_framerate,
+            depth_vis=depth_vis,
+            pointcloud_vis=pointcloud_vis,
+        )
+        self._validate_sitting_policy_contract()
 
-        # Link pose cache for FK
-        self.link_pos_: Optional[np.ndarray] = None
-        self.link_quat_: Optional[np.ndarray] = None
-        self.link_tannorm_: Optional[np.ndarray] = None
-
-    def _parse_obs_config(self):
-        super()._parse_obs_config()
-        with open(os.path.join(self.logdir, "params", "agent.yaml")) as f:
-            self.agent_cfg = yaml.unsafe_load(f)
-        
-        all_obs_names = list(self.obs_funcs.keys())
-        
-        # Separate depth observations
-        self.depth_obs_names = [obs_name for obs_name in all_obs_names if "depth" in obs_name]
-        self.proprio_obs_names = [obs_name for obs_name in all_obs_names if "depth" not in obs_name]
-        
-        # Check for motion reference observations
-        self.motion_ref_obs_names = []
-        self.proprio_obs_names_no_motion_ref = []
-        if "encoder_configs" in self.agent_cfg.get("policy", {}):
-            encoder_cfg = self.agent_cfg["policy"]["encoder_configs"]
-            if "motion_ref" in encoder_cfg:
-                self.motion_ref_obs_names = encoder_cfg["motion_ref"].get("component_names", [])
-        
-        # Proprioception excludes motion_ref if using encoder
-        if self.motion_ref_obs_names:
-            self.proprio_obs_names_no_motion_ref = [
-                n for n in self.proprio_obs_names if n not in self.motion_ref_obs_names
-            ]
-        else:
-            self.proprio_obs_names_no_motion_ref = self.proprio_obs_names
-        
-        print(f"InteractionAgent proprioception names (no motion ref): {self.proprio_obs_names_no_motion_ref}")
-        print(f"InteractionAgent depth observation names: {self.depth_obs_names}")
-        print(f"InteractionAgent motion reference names: {self.motion_ref_obs_names}")
-        
-        table = prettytable.PrettyTable()
-        table.field_names = ["Observation Name", "Function"]
-        for obs_name, func in self.obs_funcs.items():
-            table.add_row([obs_name, func.__name__])
-        print("Observation functions:")
-        print(table)
-        
-        # Parse depth config if depth observations exist
-        if self.depth_obs_names:
-            self._parse_depth_image_config()
-
-    def _parse_action_config(self):
-        super()._parse_action_config()
-        self._zero_action_joints = np.zeros(self.ros_node.NUM_ACTIONS, dtype=np.float32)
-        import re
-        for action_names, action_config in self.cfg["actions"].items():
-            for i in range(self.ros_node.NUM_JOINTS):
-                name = self.ros_node.sim_joint_names[i]
-                if "default_joint_names" in action_config:
-                    for _, joint_name_expr in enumerate(action_config["default_joint_names"]):
-                        if re.search(joint_name_expr, name):
-                            self._zero_action_joints[i] = 1.0
-
-    def _parse_depth_image_config(self):
-        """Parse depth image processing configuration from env.yaml."""
-        self.output_resolution = [
-            self.cfg["scene"]["camera"]["pattern_cfg"]["width"],
-            self.cfg["scene"]["camera"]["pattern_cfg"]["height"],
+    @classmethod
+    def _validate_checkpoint_layout(cls, logdir: str) -> None:
+        missing = [
+            os.path.join(logdir, *parts)
+            for parts in cls.REQUIRED_FILES
+            if not os.path.exists(os.path.join(logdir, *parts))
         ]
-        self.depth_range = self.cfg["scene"]["camera"]["noise_pipeline"]["depth_normalization"]["depth_range"]
-        
-        if self.cfg["scene"]["camera"]["noise_pipeline"]["depth_normalization"]["normalize"]:
-            self.depth_output_range = self.cfg["scene"]["camera"]["noise_pipeline"]["depth_normalization"]["output_range"]
-        else:
-            self.depth_output_range = self.depth_range
-        
-        if "crop_and_resize" in self.cfg["scene"]["camera"]["noise_pipeline"]:
-            self.crop_region = self.cfg["scene"]["camera"]["noise_pipeline"]["crop_and_resize"]["crop_region"]
-        if "gaussian_blur" in self.cfg["scene"]["camera"]["noise_pipeline"]:
-            self.gaussian_kernel_size = (
-                self.cfg["scene"]["camera"]["noise_pipeline"]["gaussian_blur"]["kernel_size"],
-                self.cfg["scene"]["camera"]["noise_pipeline"]["gaussian_blur"]["kernel_size"],
+        if missing:
+            raise FileNotFoundError(
+                "Interaction sitting checkpoint is incomplete. Missing: " + ", ".join(missing)
             )
-            self.gaussian_sigma = self.cfg["scene"]["camera"]["noise_pipeline"]["gaussian_blur"]["sigma"]
-        if "blind_spot" in self.cfg["scene"]["camera"]["noise_pipeline"]:
-            self.blind_spot_crop = self.cfg["scene"]["camera"]["noise_pipeline"]["blind_spot"]["crop_region"]
-        
-        self.depth_width = (
-            self.output_resolution[0] - self.crop_region[2] - self.crop_region[3]
-            if hasattr(self, "crop_region")
-            else self.output_resolution[0]
+
+    def _validate_sitting_policy_contract(self) -> None:
+        policy_obs_names = list(self.obs_funcs.keys())
+        if policy_obs_names != self.EXPECTED_POLICY_OBS:
+            raise ValueError(
+                "Interaction policy observation order mismatch. "
+                f"Expected {self.EXPECTED_POLICY_OBS}, got {policy_obs_names}."
+            )
+
+        if self.normalizer.mean.shape[0] != self.EXPECTED_RAW_OBS_DIM:
+            raise ValueError(
+                "Interaction raw observation dimension mismatch. "
+                f"Expected {self.EXPECTED_RAW_OBS_DIM}, got {self.normalizer.mean.shape[0]}."
+            )
+        height, width = self.depth_image_final_resolution
+        if (height, width) != self.EXPECTED_DEPTH_IMAGE_RESOLUTION:
+            raise ValueError(
+                "Interaction depth image resolution mismatch. "
+                f"Expected {self.EXPECTED_DEPTH_IMAGE_RESOLUTION}, got {(height, width)}."
+            )
+        if height * width != self.EXPECTED_DEPTH_DIM:
+            raise ValueError(
+                "Interaction depth image size mismatch. "
+                f"Expected {self.EXPECTED_DEPTH_DIM}, got {height * width}."
+            )
+
+        depth_encoder_input_shape = list(self.ort_sessions["depth_image_encoder"].get_inputs()[0].shape)
+        if depth_encoder_input_shape != self.EXPECTED_DEPTH_ENCODER_INPUT_SHAPE:
+            raise ValueError(
+                "Interaction depth encoder input shape mismatch. "
+                f"Expected {self.EXPECTED_DEPTH_ENCODER_INPUT_SHAPE}, got {depth_encoder_input_shape}."
+            )
+
+        depth_encoder_output_shape = self.ort_sessions["depth_image_encoder"].get_outputs()[0].shape
+        depth_latent_dim = depth_encoder_output_shape[-1]
+        if depth_latent_dim != self.EXPECTED_DEPTH_ENCODER_OUTPUT_DIM:
+            raise ValueError(
+                "Interaction depth encoder output dimension mismatch. "
+                f"Expected {self.EXPECTED_DEPTH_ENCODER_OUTPUT_DIM}, got {depth_latent_dim}."
+            )
+
+        actor_input_dim = self.ort_sessions["actor"].get_inputs()[0].shape[-1]
+        expected_actor_input_dim = (
+            self.normalizer.mean.shape[0] - self.EXPECTED_DEPTH_DIM + self.EXPECTED_DEPTH_ENCODER_OUTPUT_DIM
         )
-        self.depth_height = (
-            self.output_resolution[1] - self.crop_region[0] - self.crop_region[1]
-            if hasattr(self, "crop_region")
-            else self.output_resolution[1]
-        )
-        
-        # For sample resize
-        square_size = int(self.rs_resolution[0] // self.output_resolution[0])
-        rows, cols = self.rs_resolution[1], self.rs_resolution[0]
-        center_y_coords = np.arange(self.output_resolution[1]) * square_size + square_size // 2
-        center_x_coords = np.arange(self.output_resolution[0]) * square_size + square_size // 2
-        y_grid, x_grid = np.meshgrid(center_y_coords, center_x_coords, indexing="ij")
-        self.y_valid = np.clip(y_grid, 0, rows - 1)
-        self.x_valid = np.clip(x_grid, 0, cols - 1)
-        
-        # For downsample history
-        if "history_skip_frames" in self.cfg["observations"]["policy"]["depth_image"]["params"]:
-            downsample_factor = self.cfg["observations"]["policy"]["depth_image"]["params"]["history_skip_frames"]
-        else:
-            downsample_factor = self.cfg["observations"]["policy"]["depth_image"]["params"]["time_downsample_factor"]
-        
-        frames = int(
-            (self.cfg["scene"]["camera"]["data_histories"]["distance_to_image_plane_noised"] - 1) / downsample_factor
-            + 1
-        )
-        sim_frequency = int(1 / self.cfg["scene"]["camera"]["update_period"])
-        real_downsample_factor = int(self.rs_frequency / sim_frequency * downsample_factor)
-        self.depth_obs_indices = np.linspace(-1 - real_downsample_factor * (frames - 1), -1, frames).astype(int)
-        print(f"Depth observation downsample indices: {self.depth_obs_indices}")
-        self.depth_image_buffer = CircularBuffer(length=self.rs_frequency)
-
-    def _parse_observation_function(self, obs_name: str, obs_config: dict):
-        """Override to handle depth_image function name mapping."""
-        obs_func = obs_config["func"].split(":")[-1]
-        if obs_func == "depth_image":
-            obs_name = "depth_latent"
-            if hasattr(self, f"_get_{obs_name}_obs"):
-                self.obs_funcs[obs_name] = getattr(self, f"_get_{obs_name}_obs")
-                return
-            else:
-                raise ValueError(f"Unknown observation function for observation {obs_name}")
-        return super()._parse_observation_function(obs_name, obs_config)
-
-    def _load_models(self):
-        """Load ONNX models for the agent."""
-        ort_execution_providers = ort.get_available_providers()
-        
-        # Load actor model
-        actor_path = os.path.join(self.logdir, "exported", "actor.onnx")
-        self.ort_sessions["actor"] = ort.InferenceSession(actor_path, providers=ort_execution_providers)
-        
-        # Load depth encoder if exists
-        depth_encoder_path = os.path.join(self.logdir, "exported", "0-depth_encoder.onnx")
-        if os.path.exists(depth_encoder_path):
-            self.ort_sessions["depth_encoder"] = ort.InferenceSession(
-                depth_encoder_path, providers=ort_execution_providers
+        if actor_input_dim != expected_actor_input_dim:
+            raise ValueError(
+                "Interaction actor input dimension mismatch. "
+                f"Expected {expected_actor_input_dim}, got {actor_input_dim}."
             )
-            self.has_depth_encoder = True
-        else:
-            self.has_depth_encoder = False
-            print("Warning: No depth encoder found, depth perception disabled")
-        
-        # Load motion reference encoder if exists
-        motion_ref_path = os.path.join(self.logdir, "exported", "0-motion_ref.onnx")
-        if os.path.exists(motion_ref_path):
-            self.ort_sessions["motion_ref"] = ort.InferenceSession(
-                motion_ref_path, providers=ort_execution_providers
-            )
-            self.has_motion_ref_encoder = True
-        else:
-            self.has_motion_ref_encoder = False
-            print("Warning: No motion reference encoder found")
-        
-        # Load forward kinematics if exists
-        fk_path = os.path.join(self.logdir, "exported", "forward_kinematics.onnx")
-        if os.path.exists(fk_path):
-            self.ort_sessions["fk"] = ort.InferenceSession(fk_path, providers=ort_execution_providers)
-            self.has_fk = True
-        else:
-            self.has_fk = False
-            print("Warning: No forward kinematics model found")
-        
-        # Load normalizer if exists
-        normalizer_path = os.path.join(self.logdir, "exported", "policy_normalizer.npz")
-        if os.path.exists(normalizer_path):
-            self.normalizer = Normalizer(load_path=normalizer_path)
-        else:
-            self.normalizer = None
-        
-        print(f"Loaded ONNX models from {self.logdir}")
-
-    def _load_all_motions(self, motion_file_dir: str):
-        """Load all motion files from directory."""
-        self.all_motion_datas: dict[str, MotionData] = dict()
-        
-        if not os.path.exists(motion_file_dir):
-            print(f"Warning: Motion directory {motion_file_dir} does not exist, no motions loaded")
-            self.all_motion_datas = {}
-            self.motion_data = None
-            return
-        
-        for motion_file in os.listdir(motion_file_dir):
-            if not motion_file.endswith(".npz"):
-                continue
-            try:
-                motion = load_motion_data(
-                    os.path.join(motion_file_dir, motion_file),
-                    self.ros_node.sim_joint_names,
-                    self.target_motion_framerate,
-                )
-                self.all_motion_datas[motion_file] = motion
-            except Exception as e:
-                print(f"Warning: Failed to load motion {motion_file}: {e}")
-        
-        if self.all_motion_datas:
-            self.motion_data = list(self.all_motion_datas.values())[0]
-            self.ros_node.get_logger().info(
-                f"Loaded {len(self.all_motion_datas)} motions from {motion_file_dir}"
-            )
-        else:
-            self.motion_data = None
-            self.ros_node.get_logger().warn(f"No valid motions found in {motion_file_dir}")
-        
-        # Prepare frame indices for motion reference
-        if self.motion_data is not None and "scene" in self.cfg and "motion_reference" in self.cfg["scene"]:
-            self.motion_num_frames = self.cfg["scene"]["motion_reference"]["num_frames"]
-            self.motion_frame_indices_offset = np.arange(self.motion_num_frames).astype(float)
-            if self.cfg["scene"]["motion_reference"]["data_start_from"] == "one_frame_interval":
-                self.motion_frame_indices_offset += 1
-            self.motion_frame_indices_offset *= (
-                self.cfg["scene"]["motion_reference"]["frame_interval_s"] * self.target_motion_framerate
-            )
-            self.motion_frame_indices_offset = self.motion_frame_indices_offset.astype(int)
-        else:
-            self.motion_num_frames = 0
-            self.motion_frame_indices_offset = np.array([0])
-        
-        self.motion_cursor_idx = 0
-
-    def _update_links_poses(self):
-        """Update current link positions using forward kinematics."""
-        if not self.has_fk:
-            return
-        
-        joint_pos = self.ros_node.joint_pos_
-        fk_input_name = self.ort_sessions["fk"].get_inputs()[0].name
-        output = self.ort_sessions["fk"].run(None, {fk_input_name: joint_pos[None, :]})
-        self.link_pos_ = output[0][0]    # (num_links, 3)
-        self.link_quat_ = output[1][0]   # (num_links, 4)
-        self.link_tannorm_ = quat_to_tan_norm_batch(self.link_quat_)
-
-    def refresh_depth_frame(self):
-        """Refresh and preprocess depth frame from RealSense."""
-        self.ros_node.refresh_rs_data()
-        depth_image_np: np.ndarray = self.ros_node.rs_depth_data
-        depth_image = cv2.resize(depth_image_np, self.output_resolution, interpolation=cv2.INTER_NEAREST)
-        
-        if hasattr(self, "crop_region"):
-            shape = depth_image.shape
-            x1, x2, y1, y2 = self.crop_region
-            depth_image = depth_image[x1 : shape[0] - x2, y1 : shape[1] - y2]
-        
-        # Inpaint small holes
-        mask = (depth_image < 0.2).astype(np.uint8)
-        depth_image = cv2.inpaint(depth_image, mask, 3, cv2.INPAINT_NS)
-        
-        # Apply blind spot masking
-        if hasattr(self, "blind_spot_crop"):
-            shape = depth_image.shape
-            x1, x2, y1, y2 = self.blind_spot_crop
-            depth_image[:x1, :] = 0
-            depth_image[shape[0] - x2 :, :] = 0
-            depth_image[:, :y1] = 0
-            depth_image[:, shape[1] - y2 :] = 0
-        
-        # Gaussian blur
-        if hasattr(self, "gaussian_kernel_size"):
-            depth_image = cv2.GaussianBlur(
-                depth_image, self.gaussian_kernel_size, self.gaussian_sigma, self.gaussian_sigma
-            )
-        
-        # Normalize
-        filt_m = np.clip(depth_image, self.depth_range[0], self.depth_range[1])
-        filt_norm = (filt_m - self.depth_range[0]) / (self.depth_range[1] - self.depth_range[0])
-        output_norm = filt_norm * (
-            self.depth_output_range[1] - self.depth_output_range[0]
-        ) + self.depth_output_range[0]
-        
-        self.depth_image_buffer.append(output_norm)
-
-    def _get_depth_image_downsample_obs(self) -> np.ndarray:
-        """Get downsampled depth image observation."""
-        self.refresh_depth_frame()
-        return self.depth_image_buffer.buffer[self.depth_obs_indices, ...]
-
-    def _get_depth_latent_obs(self) -> np.ndarray:
-        """Get depth latent embedding from encoder."""
-        if not self.has_depth_encoder:
-            # Return zeros if no depth encoder
-            return np.zeros((1, 128), dtype=np.float32)  # Assuming 128-dim embedding
-        
-        depth_obs = (
-            self._get_depth_image_downsample_obs()
-            .reshape(1, -1, self.depth_height, self.depth_width)
-            .astype(np.float32)
-        )
-        return self.ort_sessions["depth_encoder"].run(
-            None, {self.ort_sessions["depth_encoder"].get_inputs()[0].name: depth_obs}
-        )[0]
-
-    def _get_object_pos_obs(self) -> np.ndarray:
-        """Get object position relative to robot base.
-        
-        Returns:
-            np.ndarray: Object position in base frame, shape (3,)
-        
-        Note: Currently returns zeros since motion data with object trajectories
-        is not yet available. Will be updated when data is provided.
-        """
-        if self.motion_data is None or self.motion_data.object_data is None:
-            return np.zeros(3, dtype=np.float32)
-        
-        obj_data = self.motion_data.object_data.get(self.object_name)
-        if obj_data is None:
-            return np.zeros(3, dtype=np.float32)
-        
-        # Get object position at current cursor
-        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
-        pos_b = obj_data.get("pos", np.zeros((self.motion_data.total_num_frames, 3)))
-        
-        # Transform to base frame (simplified - just return relative position)
-        robot_pos = self.ros_node.joint_pos_  # This is joint pos, not base pos
-        # For now, just return the object position in world frame transformed by gravity
-        # A proper implementation would use base position from motion data
-        return pos_b[cursor].astype(np.float32)
-
-    def _get_object_ori_obs(self) -> np.ndarray:
-        """Get object orientation in tangent-normal form.
-        
-        Returns:
-            np.ndarray: Object orientation, shape (6,)
-        
-        Note: Currently returns zeros since motion data with object trajectories
-        is not yet available.
-        """
-        if self.motion_data is None or self.motion_data.object_data is None:
-            return np.zeros(6, dtype=np.float32)
-        
-        obj_data = self.motion_data.object_data.get(self.object_name)
-        if obj_data is None:
-            return np.zeros(6, dtype=np.float32)
-        
-        # Get object orientation at current cursor
-        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
-        quat = obj_data.get("quat", np.zeros((self.motion_data.total_num_frames, 4)))
-        
-        # Convert to tangent-normal
-        quat_array = quaternion.from_float_array(quat[cursor:cursor+1])
-        tannorm = quat_to_tan_norm_batch(quaternion.as_float_array(quat_array))
-        
-        return tannorm.flatten().astype(np.float32)
-
-    def _get_wrist_object_contact_obs(self) -> np.ndarray:
-        """Get wrist-object contact forces.
-        
-        Returns:
-            np.ndarray: Contact forces [left, right], shape (2,)
-        
-        Note: Currently returns zeros since contact sensor data is not yet
-        available via ROS. Will be updated when contact sensors are integrated.
-        """
-        return np.zeros(2, dtype=np.float32)
-
-    def _get_link_pos_b_obs(self) -> np.ndarray:
-        """Get current link positions from FK.
-        
-        Returns:
-            np.ndarray: Link positions in base frame, shape (num_links, 3)
-        """
-        if self.link_pos_ is None:
-            return np.zeros((1, 3), dtype=np.float32)
-        return self.link_pos_.astype(np.float32)
-
-    def _get_link_tannorm_b_obs(self) -> np.ndarray:
-        """Get current link orientations in tangent-normal form.
-        
-        Returns:
-            np.ndarray: Link orientations, shape (num_links, 6)
-        """
-        if self.link_tannorm_ is None:
-            return np.zeros((1, 6), dtype=np.float32)
-        return self.link_tannorm_.astype(np.float32)
-
-    def _get_motion_ref_observation(self) -> np.ndarray:
-        """Get encoded motion reference observation.
-        
-        Returns:
-            np.ndarray: Motion reference embedding, shape (embedding_dim,)
-        """
-        if not self.has_motion_ref_encoder or self.motion_data is None:
-            return np.zeros((1, 128), dtype=np.float32)
-        
-        # Pack motion reference observations
-        motion_ref_obs = []
-        for motion_ref_obs_name in self.motion_ref_obs_names:
-            if hasattr(self, f"_get_{motion_ref_obs_name}_cmd_obs"):
-                obs_fn = getattr(self, f"_get_{motion_ref_obs_name}_cmd_obs")
-            elif hasattr(self, f"_get_{motion_ref_obs_name}_obs"):
-                obs_fn = getattr(self, f"_get_{motion_ref_obs_name}_obs")
-            else:
-                continue
-            obs_term_value = obs_fn()
-            time_dim = obs_term_value.shape[0]
-            motion_ref_obs.append(
-                obs_term_value.reshape(1, time_dim, -1).astype(np.float32)
-            )
-        
-        if not motion_ref_obs:
-            return np.zeros((1, 128), dtype=np.float32)
-        
-        motion_ref_obs = np.concatenate(motion_ref_obs, axis=-1)
-        
-        # Run motion reference encoder
-        motion_ref_input_name = self.ort_sessions["motion_ref"].get_inputs()[0].name
-        motion_ref_output = self.ort_sessions["motion_ref"].run(
-            None, {motion_ref_input_name: motion_ref_obs}
-        )[0]
-        
-        return motion_ref_output
-
-    def _get_joint_pos_ref_command_obs(self) -> np.ndarray:
-        """Get reference joint positions at future frames.
-        
-        Returns:
-            np.ndarray: Joint positions, shape (num_frames, num_joints)
-        """
-        if self.motion_data is None:
-            return np.zeros((1, self.ros_node.NUM_JOINTS), dtype=np.float32)
-        
-        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
-        frame_idx = cursor + self.motion_frame_indices_offset
-        frame_idx = np.clip(frame_idx, 0, self.motion_data.total_num_frames - 1)
-        
-        ref_joint_pos = self.motion_data.joint_pos[frame_idx] - self.ros_node.default_joint_pos[None, :]
-        return ref_joint_pos.astype(np.float32)
-
-    def _get_joint_vel_ref_command_obs(self) -> np.ndarray:
-        """Get reference joint velocities at future frames.
-        
-        Returns:
-            np.ndarray: Joint velocities, shape (num_frames, num_joints)
-        """
-        if self.motion_data is None:
-            return np.zeros((1, self.ros_node.NUM_JOINTS), dtype=np.float32)
-        
-        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
-        frame_idx = cursor + self.motion_frame_indices_offset
-        frame_idx = np.clip(frame_idx, 0, self.motion_data.total_num_frames - 1)
-        
-        return self.motion_data.joint_vel[frame_idx].astype(np.float32)
-
-    def _get_position_ref_command_obs(self) -> np.ndarray:
-        """Get reference base position at future frames.
-        
-        Returns:
-            np.ndarray: Base position relative to current, shape (num_frames, 3)
-        """
-        if self.motion_data is None:
-            return np.zeros((1, 3), dtype=np.float32)
-        
-        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
-        frame_idx = cursor + self.motion_frame_indices_offset
-        frame_idx = np.clip(frame_idx, 0, self.motion_data.total_num_frames - 1)
-        
-        # Return base position in base frame (simplified)
-        return self.motion_data.base_pos[frame_idx].astype(np.float32)
-
-    def _get_rotation_ref_command_obs(self) -> np.ndarray:
-        """Get reference base rotation in tangent-normal form.
-        
-        Returns:
-            np.ndarray: Base rotation, shape (num_frames, 6)
-        """
-        if self.motion_data is None:
-            return np.zeros((1, 6), dtype=np.float32)
-        
-        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
-        frame_idx = cursor + self.motion_frame_indices_offset
-        frame_idx = np.clip(frame_idx, 0, self.motion_data.total_num_frames - 1)
-        
-        # Convert quaternions to tangent-normal
-        base_quat = self.motion_data.base_quat[frame_idx]
-        tannorm = quat_to_tan_norm_batch(base_quat)
-        
-        return tannorm.astype(np.float32)
-
-    def _get_position_b_ref_command_obs(self) -> np.ndarray:
-        """Alias for _get_position_ref_command_obs to match env.yaml command_name."""
-        return self._get_position_ref_command_obs()
-
-    # === Aliases for env.yaml naming ===
-    def _get_object_position_obs(self) -> np.ndarray:
-        """Alias for _get_object_pos_obs to match env.yaml."""
-        return self._get_object_pos_obs()
-
-    def _get_object_orientation_tannorm_obs(self) -> np.ndarray:
-        """Alias for _get_object_ori_obs to match env.yaml."""
-        return self._get_object_ori_obs()
-
-    def _get_object_position_error_obs(self) -> np.ndarray:
-        """Alias for _get_object_pos_obs (error version uses same raw value)."""
-        return self._get_object_pos_obs()
-
-    def _get_object_orientation_error_tannorm_obs(self) -> np.ndarray:
-        """Alias for _get_object_ori_obs (error version uses same raw value)."""
-        return self._get_object_ori_obs()
-
-    # === Proxy methods to ros_node for proprioception ===
-    def _get_projected_gravity_obs(self) -> np.ndarray:
-        """Proxy to ros_node's projected_gravity from IMU."""
-        return self.ros_node._get_projected_gravity_obs()
-
-    def _get_base_ang_vel_obs(self) -> np.ndarray:
-        """Proxy to ros_node's base angular velocity from IMU."""
-        return self.ros_node._get_base_ang_vel_obs()
-
-    def _get_joint_pos_rel_obs(self) -> np.ndarray:
-        """Proxy to ros_node's joint position (relative version)."""
-        return self.ros_node._get_joint_pos_obs()
-
-    def _get_joint_vel_rel_obs(self) -> np.ndarray:
-        """Proxy to ros_node's joint velocity (relative version)."""
-        return self.ros_node._get_joint_vel_rel_obs()
-
-    def _get_last_action_obs(self) -> np.ndarray:
-        """Proxy to ros_node's last action."""
-        return self.ros_node._get_last_action_obs()
-
-    # === Object reference stubs (from motion dataset) ===
-    def _get_object_reference_position_obs(self) -> np.ndarray:
-        """Get object reference position from motion data (world frame, shape (3,))."""
-        if self.motion_data is None or self.motion_data.object_data is None:
-            return np.zeros(3, dtype=np.float32)
-        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
-        obj_pos = self.motion_data.object_data.get("box", {}).get("pos", np.zeros(3))
-        if obj_pos.ndim == 2:
-            obj_pos = obj_pos[cursor]
-        return obj_pos.astype(np.float32)
-
-    def _get_object_reference_orientation_tannorm_obs(self) -> np.ndarray:
-        """Get object reference orientation from motion data (tan-norm, shape (6,))."""
-        if self.motion_data is None or self.motion_data.object_data is None:
-            return np.zeros(6, dtype=np.float32)
-        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
-        obj_quat = self.motion_data.object_data.get("box", {}).get("quat", np.zeros(4))
-        if obj_quat.ndim == 2:
-            obj_quat = obj_quat[cursor]
-        tannorm = quat_to_tan_norm_batch(obj_quat[np.newaxis, :])[0]
-        return tannorm.astype(np.float32)
-
-    # === Contact sensor stub ===
-    def _get_seat_object_contact_obs(self) -> np.ndarray:
-        """Get contact between seat/buttocks and object (placeholder, returns zeros)."""
-        return np.zeros(2, dtype=np.float32)
-
-    def reset(self, motion_name: str = None):
-        """Reset the agent state.
-        
-        Args:
-            motion_name: Optional motion file name to load
-        """
-        super().reset()
-        
-        if motion_name is not None and motion_name in self.all_motion_datas:
-            self.motion_data = self.all_motion_datas[motion_name]
-        elif self.all_motion_datas:
-            self.motion_data = list(self.all_motion_datas.values())[0]
-        
-        self.match_to_current_heading()
-        self.motion_cursor_idx = 0
-        
-        if self.motion_data is not None:
-            self.ros_node.get_logger().info(
-                f"InteractionAgent reset with motion: {motion_name or 'default'}"
+        if actor_input_dim != self.EXPECTED_ACTOR_INPUT_DIM:
+            raise ValueError(
+                "Interaction actor input dimension changed unexpectedly. "
+                f"Expected {self.EXPECTED_ACTOR_INPUT_DIM}, got {actor_input_dim}."
             )
 
-    def get_done(self) -> bool:
-        """Check if current motion is done.
-        
-        Returns:
-            bool: True if motion cursor has reached the end
-        """
-        if self.motion_data is None:
-            return True
-        return (self.motion_cursor_idx + self.motion_frame_indices_offset[-1]) >= (
-            self.motion_data.total_num_frames - 1
-        )
 
-    def match_to_current_heading(self):
-        """Match the motion's 0-th frame to the current robot heading."""
-        if self.motion_data is None:
-            return
-        
-        root_quat_w = quaternion.from_float_array(self.ros_node._get_quat_w_obs())
-        quat_w_ref = quaternion.from_float_array(self.motion_data.base_quat[0])
-        quat_err = root_quat_w * inv_quat(quat_w_ref)
-        heading_err_quat = yaw_quat(quat_err)
-        heading_err_quat_ = np.stack(
-            [heading_err_quat for _ in range(len(self.motion_data.base_quat))], axis=0
-        )
-        
-        # Update base_quat_w for each frame
-        motion_quats = quaternion.from_float_array(self.motion_data.base_quat)
-        updated_quats = heading_err_quat_ * motion_quats
-        self.motion_data.base_quat = quaternion.as_float_array(updated_quats)
-        
-        # Update base_pos_w for each frame
-        current_pos_w = self.motion_data.base_pos[0]
-        rel_pos = self.motion_data.base_pos - self.motion_data.base_pos[0:1]
-        rotated_rel_pos = quaternion.rotate_vectors(heading_err_quat, rel_pos)
-        self.motion_data.base_pos = rotated_rel_pos + current_pos_w[None, :]
-
-    def step(self) -> tuple[np.ndarray, bool]:
-        """Perform a single step of the agent.
-        
-        Returns:
-            tuple: (action, done) where action is the policy output and
-                   done indicates if the motion has completed
-        """
-        # Update motion cursor
-        self.motion_cursor_idx += 1
-        done = self.get_done()
-        
-        # Clamp cursor to valid range
-        if self.motion_data is not None:
-            self.motion_cursor_idx = min(
-                self.motion_cursor_idx, self.motion_data.total_num_frames - 1
-            )
-        
-        # Update link poses via FK
-        self._update_links_poses()
-        
-        # Pack observations
-        proprio_obs = []
-        for proprio_obs_name in self.proprio_obs_names_no_motion_ref:
-            obs_term_value = self._get_single_obs_term(proprio_obs_name)
-            proprio_obs.append(np.reshape(obs_term_value, (1, -1)).astype(np.float32))
-        
-        # Add depth embedding if available
-        if self.has_depth_encoder and self.depth_obs_names:
-            depth_latent = self._get_depth_latent_obs()
-            proprio_obs.append(depth_latent.astype(np.float32))
-        
-        # Add motion reference embedding if available
-        if self.has_motion_ref_encoder:
-            motion_ref_emb = self._get_motion_ref_observation()
-            proprio_obs.append(motion_ref_emb.astype(np.float32))
-        
-        # Concatenate all observations
-        if proprio_obs:
-            actor_input = np.concatenate(proprio_obs, axis=-1)
-        else:
-            actor_input = np.zeros((1, 128), dtype=np.float32)
-        
-        # Apply normalization if available
-        if self.normalizer is not None:
-            actor_input = self.normalizer.normalize(actor_input.flatten()).reshape(1, -1)
-        
-        # Run actor network
-        actor_input_name = self.ort_sessions["actor"].get_inputs()[0].name
-        action = self.ort_sessions["actor"].run(None, {actor_input_name: actor_input})[0]
-        action = action.reshape(-1)
-        
-        # Reconstruct full action including zeroed joints
-        mask = (self._zero_action_joints == 0).astype(bool)
-        full_action = np.zeros(self.ros_node.NUM_ACTIONS, dtype=np.float32)
-        full_action[mask] = action
-        
-        # Publish debug info
-        if self.debug_depth_publisher is not None:
-            depth_obs = (
-                self._get_depth_image_downsample_obs()
-                .reshape(-1, self.depth_height, self.depth_width)
-            )
-            depth_image_msg_data = np.asanyarray(
-                depth_obs[-1] * 255 * 2, dtype=np.uint16
-            )
-            depth_image_msg = rnp.msgify(Image, depth_image_msg_data, encoding="16UC1")
-            depth_image_msg.header.stamp = self.ros_node.get_clock().now().to_msg()
-            depth_image_msg.header.frame_id = "realsense_depth_link"
-            self.debug_depth_publisher.publish(depth_image_msg)
-        
-        if self.debug_pointcloud_publisher is not None and hasattr(self, "depth_range"):
-            depth_obs_raw = (
-                self._get_depth_image_downsample_obs()
-                .reshape(-1, self.depth_height, self.depth_width)[-1]
-            )
-            pointcloud_msg = self.ros_node.depth_image_to_pointcloud_msg(
-                depth_obs_raw * self.depth_range[1] + self.depth_range[0]
-            )
-            self.debug_pointcloud_publisher.publish(pointcloud_msg)
-        
-        return full_action, done
-
-    def get_cold_start_agent(
-        self,
-        startup_step_size: float = 0.2,
-        kpkd_factor: float = 2.0,
-    ) -> ColdStartAgent:
-        """Get a cold start agent configured with this agent's settings.
-        
-        Args:
-            startup_step_size: Step size for cold start
-            kpkd_factor: Factor to multiply P/D gains
-        
-        Returns:
-            ColdStartAgent configured for transition to this agent
-        """
-        return ColdStartAgent(
-            startup_step_size=startup_step_size,
-            ros_node=self.ros_node,
-            joint_target_pos=self.default_joint_pos,
-            action_scale=self.action_scale,
-            action_offset=self.action_offset,
-            p_gains=self.p_gains * kpkd_factor,
-            d_gains=self.d_gains * kpkd_factor,
-        )
+__all__ = ["InteractionAgent", "MotionData"]

--- a/instinct_onboard/agents/interaction_agent.py
+++ b/instinct_onboard/agents/interaction_agent.py
@@ -621,7 +621,7 @@ class InteractionAgent(OnboardAgent):
         
         return motion_ref_output
 
-    def _get_joint_pos_ref_cmd_obs(self) -> np.ndarray:
+    def _get_joint_pos_ref_command_obs(self) -> np.ndarray:
         """Get reference joint positions at future frames.
         
         Returns:
@@ -637,7 +637,7 @@ class InteractionAgent(OnboardAgent):
         ref_joint_pos = self.motion_data.joint_pos[frame_idx] - self.ros_node.default_joint_pos[None, :]
         return ref_joint_pos.astype(np.float32)
 
-    def _get_joint_vel_ref_cmd_obs(self) -> np.ndarray:
+    def _get_joint_vel_ref_command_obs(self) -> np.ndarray:
         """Get reference joint velocities at future frames.
         
         Returns:
@@ -652,7 +652,7 @@ class InteractionAgent(OnboardAgent):
         
         return self.motion_data.joint_vel[frame_idx].astype(np.float32)
 
-    def _get_position_ref_cmd_obs(self) -> np.ndarray:
+    def _get_position_ref_command_obs(self) -> np.ndarray:
         """Get reference base position at future frames.
         
         Returns:
@@ -668,7 +668,7 @@ class InteractionAgent(OnboardAgent):
         # Return base position in base frame (simplified)
         return self.motion_data.base_pos[frame_idx].astype(np.float32)
 
-    def _get_rotation_ref_cmd_obs(self) -> np.ndarray:
+    def _get_rotation_ref_command_obs(self) -> np.ndarray:
         """Get reference base rotation in tangent-normal form.
         
         Returns:
@@ -686,6 +686,75 @@ class InteractionAgent(OnboardAgent):
         tannorm = quat_to_tan_norm_batch(base_quat)
         
         return tannorm.astype(np.float32)
+
+    def _get_position_b_ref_command_obs(self) -> np.ndarray:
+        """Alias for _get_position_ref_command_obs to match env.yaml command_name."""
+        return self._get_position_ref_command_obs()
+
+    # === Aliases for env.yaml naming ===
+    def _get_object_position_obs(self) -> np.ndarray:
+        """Alias for _get_object_pos_obs to match env.yaml."""
+        return self._get_object_pos_obs()
+
+    def _get_object_orientation_tannorm_obs(self) -> np.ndarray:
+        """Alias for _get_object_ori_obs to match env.yaml."""
+        return self._get_object_ori_obs()
+
+    def _get_object_position_error_obs(self) -> np.ndarray:
+        """Alias for _get_object_pos_obs (error version uses same raw value)."""
+        return self._get_object_pos_obs()
+
+    def _get_object_orientation_error_tannorm_obs(self) -> np.ndarray:
+        """Alias for _get_object_ori_obs (error version uses same raw value)."""
+        return self._get_object_ori_obs()
+
+    # === Proxy methods to ros_node for proprioception ===
+    def _get_projected_gravity_obs(self) -> np.ndarray:
+        """Proxy to ros_node's projected_gravity from IMU."""
+        return self.ros_node._get_projected_gravity_obs()
+
+    def _get_base_ang_vel_obs(self) -> np.ndarray:
+        """Proxy to ros_node's base angular velocity from IMU."""
+        return self.ros_node._get_base_ang_vel_obs()
+
+    def _get_joint_pos_rel_obs(self) -> np.ndarray:
+        """Proxy to ros_node's joint position (relative version)."""
+        return self.ros_node._get_joint_pos_obs()
+
+    def _get_joint_vel_rel_obs(self) -> np.ndarray:
+        """Proxy to ros_node's joint velocity (relative version)."""
+        return self.ros_node._get_joint_vel_rel_obs()
+
+    def _get_last_action_obs(self) -> np.ndarray:
+        """Proxy to ros_node's last action."""
+        return self.ros_node._get_last_action_obs()
+
+    # === Object reference stubs (from motion dataset) ===
+    def _get_object_reference_position_obs(self) -> np.ndarray:
+        """Get object reference position from motion data (world frame, shape (3,))."""
+        if self.motion_data is None or self.motion_data.object_data is None:
+            return np.zeros(3, dtype=np.float32)
+        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
+        obj_pos = self.motion_data.object_data.get("box", {}).get("pos", np.zeros(3))
+        if obj_pos.ndim == 2:
+            obj_pos = obj_pos[cursor]
+        return obj_pos.astype(np.float32)
+
+    def _get_object_reference_orientation_tannorm_obs(self) -> np.ndarray:
+        """Get object reference orientation from motion data (tan-norm, shape (6,))."""
+        if self.motion_data is None or self.motion_data.object_data is None:
+            return np.zeros(6, dtype=np.float32)
+        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
+        obj_quat = self.motion_data.object_data.get("box", {}).get("quat", np.zeros(4))
+        if obj_quat.ndim == 2:
+            obj_quat = obj_quat[cursor]
+        tannorm = quat_to_tan_norm_batch(obj_quat[np.newaxis, :])[0]
+        return tannorm.astype(np.float32)
+
+    # === Contact sensor stub ===
+    def _get_seat_object_contact_obs(self) -> np.ndarray:
+        """Get contact between seat/buttocks and object (placeholder, returns zeros)."""
+        return np.zeros(2, dtype=np.float32)
 
     def reset(self, motion_name: str = None):
         """Reset the agent state.

--- a/instinct_onboard/agents/interaction_agent.py
+++ b/instinct_onboard/agents/interaction_agent.py
@@ -1,0 +1,851 @@
+"""
+InteractionAgent for instinct_onboard.
+
+This agent combines:
+- Depth perception from ParkourAgent (0-depth_encoder.onnx)
+- Motion reference tracking from ShadowingAgent (0-motion_ref.onnx, forward_kinematics.onnx)
+- Object state observations (object_pos, object_ori, wrist_object_contact)
+
+Reference:
+- ParkourAgent: depth image processing and velocity command
+- ShadowingAgent: motion reference encoding and FK
+- TrackerAgent: NPZ file loading pattern
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+import cv2
+import numpy as np
+import onnxruntime as ort
+import prettytable
+import quaternion
+import ros2_numpy as rnp
+import yaml
+from geometry_msgs.msg import TransformStamped
+from sensor_msgs.msg import Image, PointCloud2, PointField
+
+from instinct_onboard.agents.base import ColdStartAgent, OnboardAgent
+from instinct_onboard.normalizer import Normalizer
+from instinct_onboard.ros_nodes.base import RealNode
+from instinct_onboard.utils import (
+    CircularBuffer,
+    inv_quat,
+    quat_rotate_inverse,
+    quat_slerp_batch,
+    quat_to_tan_norm_batch,
+    yaw_quat,
+)
+
+
+@dataclass
+class MotionData:
+    """Motion data structure for interaction task.
+    
+    Compared to TrackerAgent's MotionData, this adds object_data field
+    for object state trajectories.
+    """
+    framerate: float
+    # Joint orders must match the robot joint names in simulation order.
+    joint_pos: np.ndarray  # (N, num_joints)
+    joint_vel: np.ndarray  # (N, num_joints)
+    base_pos: np.ndarray   # (N, 3)
+    base_quat: np.ndarray   # (N, 4)
+    total_num_frames: int
+    # Object data - stored as dict for flexibility
+    # Expected keys: "box" -> {pos, quat, lin_vel, ang_vel, contact, validity}
+    object_data: Optional[Dict[str, np.ndarray]] = None
+
+
+def load_motion_data(
+    motion_file: str,
+    robot_joint_names: list[str],
+    target_framerate: float,
+) -> MotionData:
+    """Load motion data from NPZ file, compatible with interaction task.
+    
+    Handles both standard motion data and motion data with object trajectories.
+    """
+    motion_data = np.load(motion_file, allow_pickle=True)
+    framerate = motion_data["framerate"].item()
+
+    motion_joint_names_all = motion_data["joint_names"].tolist()
+    motion_joint_to_robot_joint_ids = [motion_joint_names_all.index(j_name) for j_name in robot_joint_names]
+
+    joint_pos = motion_data["joint_pos"][:, motion_joint_to_robot_joint_ids]
+    joint_pos_ = np.concatenate([joint_pos[0:1], joint_pos])
+    joint_vel = (joint_pos_[1:] - joint_pos_[:-1]) * framerate
+    base_pos = motion_data["base_pos_w"]
+    base_quat = motion_data["base_quat_w"]
+    total_num_frames = motion_data["joint_pos"].shape[0]
+
+    # Try to load object data if available
+    object_data = None
+    if "object_data" in motion_data.files:
+        object_data = motion_data["object_data"].item()  # Convert from numpy dict to python dict
+
+    motion = MotionData(
+        framerate=framerate,
+        joint_pos=joint_pos,
+        joint_vel=joint_vel,
+        base_pos=base_pos,
+        base_quat=base_quat,
+        total_num_frames=total_num_frames,
+        object_data=object_data,
+    )
+
+    return match_framerate(motion, target_framerate)
+
+
+def match_framerate(motion_data: MotionData, target_framerate: float) -> MotionData:
+    """Resample motion data to target framerate."""
+    if motion_data.framerate == target_framerate:
+        return motion_data
+
+    motion_length_s = motion_data.total_num_frames / motion_data.framerate
+    new_total_num_frames = math.floor(motion_length_s * target_framerate)
+    new_frame_idxs = np.linspace(0, motion_data.total_num_frames - 1, new_total_num_frames)
+    floor = np.floor(new_frame_idxs).astype(int)
+    ceil = np.ceil(new_frame_idxs).astype(int)
+    frac = new_frame_idxs - floor
+
+    new_joint_pos = (1 - frac)[:, None] * motion_data.joint_pos[floor] + frac[:, None] * motion_data.joint_pos[ceil]
+    joint_pos_ = np.concatenate([new_joint_pos[0:1], new_joint_pos])
+    new_joint_vel = (joint_pos_[1:] - joint_pos_[:-1]) * target_framerate
+    new_base_pos = (1 - frac)[:, None] * motion_data.base_pos[floor] + frac[:, None] * motion_data.base_pos[ceil]
+    new_base_quat = quat_slerp_batch(motion_data.base_quat[floor], motion_data.base_quat[ceil], frac)
+
+    # Resample object data if available
+    new_object_data = None
+    if motion_data.object_data is not None:
+        new_object_data = {}
+        for obj_name, obj_arrays in motion_data.object_data.items():
+            if isinstance(obj_arrays, dict):
+                # Object state dict with pos, quat, lin_vel, ang_vel, contact, validity
+                new_object_data[obj_name] = {
+                    key: (1 - frac)[:, None] * val[floor] + frac[:, None] * val[ceil]
+                    if val.ndim == 2 and val.shape[0] == motion_data.total_num_frames
+                    else val
+                    for key, val in obj_arrays.items()
+                }
+            else:
+                # Simple array
+                new_object_data[obj_name] = (
+                    (1 - frac)[:, None] * obj_arrays[floor] + frac[:, None] * obj_arrays[ceil]
+                )
+
+    return MotionData(
+        framerate=target_framerate,
+        joint_pos=new_joint_pos.astype(np.float32),
+        joint_vel=new_joint_vel.astype(np.float32),
+        base_pos=new_base_pos.astype(np.float32),
+        base_quat=new_base_quat.astype(np.float32),
+        total_num_frames=new_total_num_frames,
+        object_data=new_object_data,
+    )
+
+
+class InteractionAgent(OnboardAgent):
+    """Agent for interaction tasks combining depth perception, motion reference, and object state.
+    
+    This agent loads:
+    - actor.onnx: Policy network
+    - 0-depth_encoder.onnx: Depth image encoder
+    - 0-motion_ref.onnx: Motion reference encoder (optional)
+    - forward_kinematics.onnx: FK for link positions
+    
+    Observations include:
+    - Proprioception: joint_pos, joint_vel, projected_gravity, base_ang_vel, last_action
+    - Depth: depth_latent (from depth encoder)
+    - Motion reference: joint_pos_ref, joint_vel_ref, position_ref, rotation_ref
+    - Object state: object_pos, object_ori (relative to base frame)
+    - Contact: wrist_object_contact
+    
+    Since motion data is not yet available, object-related observations return zeros.
+    """
+
+    rs_resolution = (480, 270)
+    rs_frequency = 60
+
+    def __init__(
+        self,
+        logdir: str,
+        motion_file_dir: str,
+        ros_node: RealNode,
+        depth_vis: bool = True,
+        pointcloud_vis: bool = True,
+        target_motion_framerate: float = 50.0,
+        object_name: str = "box",
+    ):
+        super().__init__(logdir, ros_node)
+        self.target_motion_framerate = target_motion_framerate
+        self.object_name = object_name
+        self.ort_sessions: dict[str, ort.InferenceSession] = dict()
+        self._parse_obs_config()
+        self._parse_action_config()
+        self._load_models()
+        self._load_all_motions(motion_file_dir)
+        
+        # Depth visualization
+        self.depth_vis = depth_vis
+        if self.depth_vis:
+            self.debug_depth_publisher = ros_node.create_publisher(Image, "/debug/depth_image", 10)
+        else:
+            self.debug_depth_publisher = None
+        
+        self.pointcloud_vis = pointcloud_vis
+        if self.pointcloud_vis:
+            self.debug_pointcloud_publisher = ros_node.create_publisher(PointCloud2, "/debug/pointcloud", 10)
+        else:
+            self.debug_pointcloud_publisher = None
+
+        # Link pose cache for FK
+        self.link_pos_: Optional[np.ndarray] = None
+        self.link_quat_: Optional[np.ndarray] = None
+        self.link_tannorm_: Optional[np.ndarray] = None
+
+    def _parse_obs_config(self):
+        super()._parse_obs_config()
+        with open(os.path.join(self.logdir, "params", "agent.yaml")) as f:
+            self.agent_cfg = yaml.unsafe_load(f)
+        
+        all_obs_names = list(self.obs_funcs.keys())
+        
+        # Separate depth observations
+        self.depth_obs_names = [obs_name for obs_name in all_obs_names if "depth" in obs_name]
+        self.proprio_obs_names = [obs_name for obs_name in all_obs_names if "depth" not in obs_name]
+        
+        # Check for motion reference observations
+        self.motion_ref_obs_names = []
+        self.proprio_obs_names_no_motion_ref = []
+        if "encoder_configs" in self.agent_cfg.get("policy", {}):
+            encoder_cfg = self.agent_cfg["policy"]["encoder_configs"]
+            if "motion_ref" in encoder_cfg:
+                self.motion_ref_obs_names = encoder_cfg["motion_ref"].get("component_names", [])
+        
+        # Proprioception excludes motion_ref if using encoder
+        if self.motion_ref_obs_names:
+            self.proprio_obs_names_no_motion_ref = [
+                n for n in self.proprio_obs_names if n not in self.motion_ref_obs_names
+            ]
+        else:
+            self.proprio_obs_names_no_motion_ref = self.proprio_obs_names
+        
+        print(f"InteractionAgent proprioception names (no motion ref): {self.proprio_obs_names_no_motion_ref}")
+        print(f"InteractionAgent depth observation names: {self.depth_obs_names}")
+        print(f"InteractionAgent motion reference names: {self.motion_ref_obs_names}")
+        
+        table = prettytable.PrettyTable()
+        table.field_names = ["Observation Name", "Function"]
+        for obs_name, func in self.obs_funcs.items():
+            table.add_row([obs_name, func.__name__])
+        print("Observation functions:")
+        print(table)
+        
+        # Parse depth config if depth observations exist
+        if self.depth_obs_names:
+            self._parse_depth_image_config()
+
+    def _parse_action_config(self):
+        super()._parse_action_config()
+        self._zero_action_joints = np.zeros(self.ros_node.NUM_ACTIONS, dtype=np.float32)
+        import re
+        for action_names, action_config in self.cfg["actions"].items():
+            for i in range(self.ros_node.NUM_JOINTS):
+                name = self.ros_node.sim_joint_names[i]
+                if "default_joint_names" in action_config:
+                    for _, joint_name_expr in enumerate(action_config["default_joint_names"]):
+                        if re.search(joint_name_expr, name):
+                            self._zero_action_joints[i] = 1.0
+
+    def _parse_depth_image_config(self):
+        """Parse depth image processing configuration from env.yaml."""
+        self.output_resolution = [
+            self.cfg["scene"]["camera"]["pattern_cfg"]["width"],
+            self.cfg["scene"]["camera"]["pattern_cfg"]["height"],
+        ]
+        self.depth_range = self.cfg["scene"]["camera"]["noise_pipeline"]["depth_normalization"]["depth_range"]
+        
+        if self.cfg["scene"]["camera"]["noise_pipeline"]["depth_normalization"]["normalize"]:
+            self.depth_output_range = self.cfg["scene"]["camera"]["noise_pipeline"]["depth_normalization"]["output_range"]
+        else:
+            self.depth_output_range = self.depth_range
+        
+        if "crop_and_resize" in self.cfg["scene"]["camera"]["noise_pipeline"]:
+            self.crop_region = self.cfg["scene"]["camera"]["noise_pipeline"]["crop_and_resize"]["crop_region"]
+        if "gaussian_blur" in self.cfg["scene"]["camera"]["noise_pipeline"]:
+            self.gaussian_kernel_size = (
+                self.cfg["scene"]["camera"]["noise_pipeline"]["gaussian_blur"]["kernel_size"],
+                self.cfg["scene"]["camera"]["noise_pipeline"]["gaussian_blur"]["kernel_size"],
+            )
+            self.gaussian_sigma = self.cfg["scene"]["camera"]["noise_pipeline"]["gaussian_blur"]["sigma"]
+        if "blind_spot" in self.cfg["scene"]["camera"]["noise_pipeline"]:
+            self.blind_spot_crop = self.cfg["scene"]["camera"]["noise_pipeline"]["blind_spot"]["crop_region"]
+        
+        self.depth_width = (
+            self.output_resolution[0] - self.crop_region[2] - self.crop_region[3]
+            if hasattr(self, "crop_region")
+            else self.output_resolution[0]
+        )
+        self.depth_height = (
+            self.output_resolution[1] - self.crop_region[0] - self.crop_region[1]
+            if hasattr(self, "crop_region")
+            else self.output_resolution[1]
+        )
+        
+        # For sample resize
+        square_size = int(self.rs_resolution[0] // self.output_resolution[0])
+        rows, cols = self.rs_resolution[1], self.rs_resolution[0]
+        center_y_coords = np.arange(self.output_resolution[1]) * square_size + square_size // 2
+        center_x_coords = np.arange(self.output_resolution[0]) * square_size + square_size // 2
+        y_grid, x_grid = np.meshgrid(center_y_coords, center_x_coords, indexing="ij")
+        self.y_valid = np.clip(y_grid, 0, rows - 1)
+        self.x_valid = np.clip(x_grid, 0, cols - 1)
+        
+        # For downsample history
+        if "history_skip_frames" in self.cfg["observations"]["policy"]["depth_image"]["params"]:
+            downsample_factor = self.cfg["observations"]["policy"]["depth_image"]["params"]["history_skip_frames"]
+        else:
+            downsample_factor = self.cfg["observations"]["policy"]["depth_image"]["params"]["time_downsample_factor"]
+        
+        frames = int(
+            (self.cfg["scene"]["camera"]["data_histories"]["distance_to_image_plane_noised"] - 1) / downsample_factor
+            + 1
+        )
+        sim_frequency = int(1 / self.cfg["scene"]["camera"]["update_period"])
+        real_downsample_factor = int(self.rs_frequency / sim_frequency * downsample_factor)
+        self.depth_obs_indices = np.linspace(-1 - real_downsample_factor * (frames - 1), -1, frames).astype(int)
+        print(f"Depth observation downsample indices: {self.depth_obs_indices}")
+        self.depth_image_buffer = CircularBuffer(length=self.rs_frequency)
+
+    def _parse_observation_function(self, obs_name: str, obs_config: dict):
+        """Override to handle depth_image function name mapping."""
+        obs_func = obs_config["func"].split(":")[-1]
+        if obs_func == "depth_image":
+            obs_name = "depth_latent"
+            if hasattr(self, f"_get_{obs_name}_obs"):
+                self.obs_funcs[obs_name] = getattr(self, f"_get_{obs_name}_obs")
+                return
+            else:
+                raise ValueError(f"Unknown observation function for observation {obs_name}")
+        return super()._parse_observation_function(obs_name, obs_config)
+
+    def _load_models(self):
+        """Load ONNX models for the agent."""
+        ort_execution_providers = ort.get_available_providers()
+        
+        # Load actor model
+        actor_path = os.path.join(self.logdir, "exported", "actor.onnx")
+        self.ort_sessions["actor"] = ort.InferenceSession(actor_path, providers=ort_execution_providers)
+        
+        # Load depth encoder if exists
+        depth_encoder_path = os.path.join(self.logdir, "exported", "0-depth_encoder.onnx")
+        if os.path.exists(depth_encoder_path):
+            self.ort_sessions["depth_encoder"] = ort.InferenceSession(
+                depth_encoder_path, providers=ort_execution_providers
+            )
+            self.has_depth_encoder = True
+        else:
+            self.has_depth_encoder = False
+            print("Warning: No depth encoder found, depth perception disabled")
+        
+        # Load motion reference encoder if exists
+        motion_ref_path = os.path.join(self.logdir, "exported", "0-motion_ref.onnx")
+        if os.path.exists(motion_ref_path):
+            self.ort_sessions["motion_ref"] = ort.InferenceSession(
+                motion_ref_path, providers=ort_execution_providers
+            )
+            self.has_motion_ref_encoder = True
+        else:
+            self.has_motion_ref_encoder = False
+            print("Warning: No motion reference encoder found")
+        
+        # Load forward kinematics if exists
+        fk_path = os.path.join(self.logdir, "exported", "forward_kinematics.onnx")
+        if os.path.exists(fk_path):
+            self.ort_sessions["fk"] = ort.InferenceSession(fk_path, providers=ort_execution_providers)
+            self.has_fk = True
+        else:
+            self.has_fk = False
+            print("Warning: No forward kinematics model found")
+        
+        # Load normalizer if exists
+        normalizer_path = os.path.join(self.logdir, "exported", "policy_normalizer.npz")
+        if os.path.exists(normalizer_path):
+            self.normalizer = Normalizer(load_path=normalizer_path)
+        else:
+            self.normalizer = None
+        
+        print(f"Loaded ONNX models from {self.logdir}")
+
+    def _load_all_motions(self, motion_file_dir: str):
+        """Load all motion files from directory."""
+        self.all_motion_datas: dict[str, MotionData] = dict()
+        
+        if not os.path.exists(motion_file_dir):
+            print(f"Warning: Motion directory {motion_file_dir} does not exist, no motions loaded")
+            self.all_motion_datas = {}
+            self.motion_data = None
+            return
+        
+        for motion_file in os.listdir(motion_file_dir):
+            if not motion_file.endswith(".npz"):
+                continue
+            try:
+                motion = load_motion_data(
+                    os.path.join(motion_file_dir, motion_file),
+                    self.ros_node.sim_joint_names,
+                    self.target_motion_framerate,
+                )
+                self.all_motion_datas[motion_file] = motion
+            except Exception as e:
+                print(f"Warning: Failed to load motion {motion_file}: {e}")
+        
+        if self.all_motion_datas:
+            self.motion_data = list(self.all_motion_datas.values())[0]
+            self.ros_node.get_logger().info(
+                f"Loaded {len(self.all_motion_datas)} motions from {motion_file_dir}"
+            )
+        else:
+            self.motion_data = None
+            self.ros_node.get_logger().warn(f"No valid motions found in {motion_file_dir}")
+        
+        # Prepare frame indices for motion reference
+        if self.motion_data is not None and "scene" in self.cfg and "motion_reference" in self.cfg["scene"]:
+            self.motion_num_frames = self.cfg["scene"]["motion_reference"]["num_frames"]
+            self.motion_frame_indices_offset = np.arange(self.motion_num_frames).astype(float)
+            if self.cfg["scene"]["motion_reference"]["data_start_from"] == "one_frame_interval":
+                self.motion_frame_indices_offset += 1
+            self.motion_frame_indices_offset *= (
+                self.cfg["scene"]["motion_reference"]["frame_interval_s"] * self.target_motion_framerate
+            )
+            self.motion_frame_indices_offset = self.motion_frame_indices_offset.astype(int)
+        else:
+            self.motion_num_frames = 0
+            self.motion_frame_indices_offset = np.array([0])
+        
+        self.motion_cursor_idx = 0
+
+    def _update_links_poses(self):
+        """Update current link positions using forward kinematics."""
+        if not self.has_fk:
+            return
+        
+        joint_pos = self.ros_node.joint_pos_
+        fk_input_name = self.ort_sessions["fk"].get_inputs()[0].name
+        output = self.ort_sessions["fk"].run(None, {fk_input_name: joint_pos[None, :]})
+        self.link_pos_ = output[0][0]    # (num_links, 3)
+        self.link_quat_ = output[1][0]   # (num_links, 4)
+        self.link_tannorm_ = quat_to_tan_norm_batch(self.link_quat_)
+
+    def refresh_depth_frame(self):
+        """Refresh and preprocess depth frame from RealSense."""
+        self.ros_node.refresh_rs_data()
+        depth_image_np: np.ndarray = self.ros_node.rs_depth_data
+        depth_image = cv2.resize(depth_image_np, self.output_resolution, interpolation=cv2.INTER_NEAREST)
+        
+        if hasattr(self, "crop_region"):
+            shape = depth_image.shape
+            x1, x2, y1, y2 = self.crop_region
+            depth_image = depth_image[x1 : shape[0] - x2, y1 : shape[1] - y2]
+        
+        # Inpaint small holes
+        mask = (depth_image < 0.2).astype(np.uint8)
+        depth_image = cv2.inpaint(depth_image, mask, 3, cv2.INPAINT_NS)
+        
+        # Apply blind spot masking
+        if hasattr(self, "blind_spot_crop"):
+            shape = depth_image.shape
+            x1, x2, y1, y2 = self.blind_spot_crop
+            depth_image[:x1, :] = 0
+            depth_image[shape[0] - x2 :, :] = 0
+            depth_image[:, :y1] = 0
+            depth_image[:, shape[1] - y2 :] = 0
+        
+        # Gaussian blur
+        if hasattr(self, "gaussian_kernel_size"):
+            depth_image = cv2.GaussianBlur(
+                depth_image, self.gaussian_kernel_size, self.gaussian_sigma, self.gaussian_sigma
+            )
+        
+        # Normalize
+        filt_m = np.clip(depth_image, self.depth_range[0], self.depth_range[1])
+        filt_norm = (filt_m - self.depth_range[0]) / (self.depth_range[1] - self.depth_range[0])
+        output_norm = filt_norm * (
+            self.depth_output_range[1] - self.depth_output_range[0]
+        ) + self.depth_output_range[0]
+        
+        self.depth_image_buffer.append(output_norm)
+
+    def _get_depth_image_downsample_obs(self) -> np.ndarray:
+        """Get downsampled depth image observation."""
+        self.refresh_depth_frame()
+        return self.depth_image_buffer.buffer[self.depth_obs_indices, ...]
+
+    def _get_depth_latent_obs(self) -> np.ndarray:
+        """Get depth latent embedding from encoder."""
+        if not self.has_depth_encoder:
+            # Return zeros if no depth encoder
+            return np.zeros((1, 128), dtype=np.float32)  # Assuming 128-dim embedding
+        
+        depth_obs = (
+            self._get_depth_image_downsample_obs()
+            .reshape(1, -1, self.depth_height, self.depth_width)
+            .astype(np.float32)
+        )
+        return self.ort_sessions["depth_encoder"].run(
+            None, {self.ort_sessions["depth_encoder"].get_inputs()[0].name: depth_obs}
+        )[0]
+
+    def _get_object_pos_obs(self) -> np.ndarray:
+        """Get object position relative to robot base.
+        
+        Returns:
+            np.ndarray: Object position in base frame, shape (3,)
+        
+        Note: Currently returns zeros since motion data with object trajectories
+        is not yet available. Will be updated when data is provided.
+        """
+        if self.motion_data is None or self.motion_data.object_data is None:
+            return np.zeros(3, dtype=np.float32)
+        
+        obj_data = self.motion_data.object_data.get(self.object_name)
+        if obj_data is None:
+            return np.zeros(3, dtype=np.float32)
+        
+        # Get object position at current cursor
+        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
+        pos_b = obj_data.get("pos", np.zeros((self.motion_data.total_num_frames, 3)))
+        
+        # Transform to base frame (simplified - just return relative position)
+        robot_pos = self.ros_node.joint_pos_  # This is joint pos, not base pos
+        # For now, just return the object position in world frame transformed by gravity
+        # A proper implementation would use base position from motion data
+        return pos_b[cursor].astype(np.float32)
+
+    def _get_object_ori_obs(self) -> np.ndarray:
+        """Get object orientation in tangent-normal form.
+        
+        Returns:
+            np.ndarray: Object orientation, shape (6,)
+        
+        Note: Currently returns zeros since motion data with object trajectories
+        is not yet available.
+        """
+        if self.motion_data is None or self.motion_data.object_data is None:
+            return np.zeros(6, dtype=np.float32)
+        
+        obj_data = self.motion_data.object_data.get(self.object_name)
+        if obj_data is None:
+            return np.zeros(6, dtype=np.float32)
+        
+        # Get object orientation at current cursor
+        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
+        quat = obj_data.get("quat", np.zeros((self.motion_data.total_num_frames, 4)))
+        
+        # Convert to tangent-normal
+        quat_array = quaternion.from_float_array(quat[cursor:cursor+1])
+        tannorm = quat_to_tan_norm_batch(quaternion.as_float_array(quat_array))
+        
+        return tannorm.flatten().astype(np.float32)
+
+    def _get_wrist_object_contact_obs(self) -> np.ndarray:
+        """Get wrist-object contact forces.
+        
+        Returns:
+            np.ndarray: Contact forces [left, right], shape (2,)
+        
+        Note: Currently returns zeros since contact sensor data is not yet
+        available via ROS. Will be updated when contact sensors are integrated.
+        """
+        return np.zeros(2, dtype=np.float32)
+
+    def _get_link_pos_b_obs(self) -> np.ndarray:
+        """Get current link positions from FK.
+        
+        Returns:
+            np.ndarray: Link positions in base frame, shape (num_links, 3)
+        """
+        if self.link_pos_ is None:
+            return np.zeros((1, 3), dtype=np.float32)
+        return self.link_pos_.astype(np.float32)
+
+    def _get_link_tannorm_b_obs(self) -> np.ndarray:
+        """Get current link orientations in tangent-normal form.
+        
+        Returns:
+            np.ndarray: Link orientations, shape (num_links, 6)
+        """
+        if self.link_tannorm_ is None:
+            return np.zeros((1, 6), dtype=np.float32)
+        return self.link_tannorm_.astype(np.float32)
+
+    def _get_motion_ref_observation(self) -> np.ndarray:
+        """Get encoded motion reference observation.
+        
+        Returns:
+            np.ndarray: Motion reference embedding, shape (embedding_dim,)
+        """
+        if not self.has_motion_ref_encoder or self.motion_data is None:
+            return np.zeros((1, 128), dtype=np.float32)
+        
+        # Pack motion reference observations
+        motion_ref_obs = []
+        for motion_ref_obs_name in self.motion_ref_obs_names:
+            if hasattr(self, f"_get_{motion_ref_obs_name}_cmd_obs"):
+                obs_fn = getattr(self, f"_get_{motion_ref_obs_name}_cmd_obs")
+            elif hasattr(self, f"_get_{motion_ref_obs_name}_obs"):
+                obs_fn = getattr(self, f"_get_{motion_ref_obs_name}_obs")
+            else:
+                continue
+            obs_term_value = obs_fn()
+            time_dim = obs_term_value.shape[0]
+            motion_ref_obs.append(
+                obs_term_value.reshape(1, time_dim, -1).astype(np.float32)
+            )
+        
+        if not motion_ref_obs:
+            return np.zeros((1, 128), dtype=np.float32)
+        
+        motion_ref_obs = np.concatenate(motion_ref_obs, axis=-1)
+        
+        # Run motion reference encoder
+        motion_ref_input_name = self.ort_sessions["motion_ref"].get_inputs()[0].name
+        motion_ref_output = self.ort_sessions["motion_ref"].run(
+            None, {motion_ref_input_name: motion_ref_obs}
+        )[0]
+        
+        return motion_ref_output
+
+    def _get_joint_pos_ref_cmd_obs(self) -> np.ndarray:
+        """Get reference joint positions at future frames.
+        
+        Returns:
+            np.ndarray: Joint positions, shape (num_frames, num_joints)
+        """
+        if self.motion_data is None:
+            return np.zeros((1, self.ros_node.NUM_JOINTS), dtype=np.float32)
+        
+        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
+        frame_idx = cursor + self.motion_frame_indices_offset
+        frame_idx = np.clip(frame_idx, 0, self.motion_data.total_num_frames - 1)
+        
+        ref_joint_pos = self.motion_data.joint_pos[frame_idx] - self.ros_node.default_joint_pos[None, :]
+        return ref_joint_pos.astype(np.float32)
+
+    def _get_joint_vel_ref_cmd_obs(self) -> np.ndarray:
+        """Get reference joint velocities at future frames.
+        
+        Returns:
+            np.ndarray: Joint velocities, shape (num_frames, num_joints)
+        """
+        if self.motion_data is None:
+            return np.zeros((1, self.ros_node.NUM_JOINTS), dtype=np.float32)
+        
+        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
+        frame_idx = cursor + self.motion_frame_indices_offset
+        frame_idx = np.clip(frame_idx, 0, self.motion_data.total_num_frames - 1)
+        
+        return self.motion_data.joint_vel[frame_idx].astype(np.float32)
+
+    def _get_position_ref_cmd_obs(self) -> np.ndarray:
+        """Get reference base position at future frames.
+        
+        Returns:
+            np.ndarray: Base position relative to current, shape (num_frames, 3)
+        """
+        if self.motion_data is None:
+            return np.zeros((1, 3), dtype=np.float32)
+        
+        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
+        frame_idx = cursor + self.motion_frame_indices_offset
+        frame_idx = np.clip(frame_idx, 0, self.motion_data.total_num_frames - 1)
+        
+        # Return base position in base frame (simplified)
+        return self.motion_data.base_pos[frame_idx].astype(np.float32)
+
+    def _get_rotation_ref_cmd_obs(self) -> np.ndarray:
+        """Get reference base rotation in tangent-normal form.
+        
+        Returns:
+            np.ndarray: Base rotation, shape (num_frames, 6)
+        """
+        if self.motion_data is None:
+            return np.zeros((1, 6), dtype=np.float32)
+        
+        cursor = min(self.motion_cursor_idx, self.motion_data.total_num_frames - 1)
+        frame_idx = cursor + self.motion_frame_indices_offset
+        frame_idx = np.clip(frame_idx, 0, self.motion_data.total_num_frames - 1)
+        
+        # Convert quaternions to tangent-normal
+        base_quat = self.motion_data.base_quat[frame_idx]
+        tannorm = quat_to_tan_norm_batch(base_quat)
+        
+        return tannorm.astype(np.float32)
+
+    def reset(self, motion_name: str = None):
+        """Reset the agent state.
+        
+        Args:
+            motion_name: Optional motion file name to load
+        """
+        super().reset()
+        
+        if motion_name is not None and motion_name in self.all_motion_datas:
+            self.motion_data = self.all_motion_datas[motion_name]
+        elif self.all_motion_datas:
+            self.motion_data = list(self.all_motion_datas.values())[0]
+        
+        self.match_to_current_heading()
+        self.motion_cursor_idx = 0
+        
+        if self.motion_data is not None:
+            self.ros_node.get_logger().info(
+                f"InteractionAgent reset with motion: {motion_name or 'default'}"
+            )
+
+    def get_done(self) -> bool:
+        """Check if current motion is done.
+        
+        Returns:
+            bool: True if motion cursor has reached the end
+        """
+        if self.motion_data is None:
+            return True
+        return (self.motion_cursor_idx + self.motion_frame_indices_offset[-1]) >= (
+            self.motion_data.total_num_frames - 1
+        )
+
+    def match_to_current_heading(self):
+        """Match the motion's 0-th frame to the current robot heading."""
+        if self.motion_data is None:
+            return
+        
+        root_quat_w = quaternion.from_float_array(self.ros_node._get_quat_w_obs())
+        quat_w_ref = quaternion.from_float_array(self.motion_data.base_quat[0])
+        quat_err = root_quat_w * inv_quat(quat_w_ref)
+        heading_err_quat = yaw_quat(quat_err)
+        heading_err_quat_ = np.stack(
+            [heading_err_quat for _ in range(len(self.motion_data.base_quat))], axis=0
+        )
+        
+        # Update base_quat_w for each frame
+        motion_quats = quaternion.from_float_array(self.motion_data.base_quat)
+        updated_quats = heading_err_quat_ * motion_quats
+        self.motion_data.base_quat = quaternion.as_float_array(updated_quats)
+        
+        # Update base_pos_w for each frame
+        current_pos_w = self.motion_data.base_pos[0]
+        rel_pos = self.motion_data.base_pos - self.motion_data.base_pos[0:1]
+        rotated_rel_pos = quaternion.rotate_vectors(heading_err_quat, rel_pos)
+        self.motion_data.base_pos = rotated_rel_pos + current_pos_w[None, :]
+
+    def step(self) -> tuple[np.ndarray, bool]:
+        """Perform a single step of the agent.
+        
+        Returns:
+            tuple: (action, done) where action is the policy output and
+                   done indicates if the motion has completed
+        """
+        # Update motion cursor
+        self.motion_cursor_idx += 1
+        done = self.get_done()
+        
+        # Clamp cursor to valid range
+        if self.motion_data is not None:
+            self.motion_cursor_idx = min(
+                self.motion_cursor_idx, self.motion_data.total_num_frames - 1
+            )
+        
+        # Update link poses via FK
+        self._update_links_poses()
+        
+        # Pack observations
+        proprio_obs = []
+        for proprio_obs_name in self.proprio_obs_names_no_motion_ref:
+            obs_term_value = self._get_single_obs_term(proprio_obs_name)
+            proprio_obs.append(np.reshape(obs_term_value, (1, -1)).astype(np.float32))
+        
+        # Add depth embedding if available
+        if self.has_depth_encoder and self.depth_obs_names:
+            depth_latent = self._get_depth_latent_obs()
+            proprio_obs.append(depth_latent.astype(np.float32))
+        
+        # Add motion reference embedding if available
+        if self.has_motion_ref_encoder:
+            motion_ref_emb = self._get_motion_ref_observation()
+            proprio_obs.append(motion_ref_emb.astype(np.float32))
+        
+        # Concatenate all observations
+        if proprio_obs:
+            actor_input = np.concatenate(proprio_obs, axis=-1)
+        else:
+            actor_input = np.zeros((1, 128), dtype=np.float32)
+        
+        # Apply normalization if available
+        if self.normalizer is not None:
+            actor_input = self.normalizer.normalize(actor_input.flatten()).reshape(1, -1)
+        
+        # Run actor network
+        actor_input_name = self.ort_sessions["actor"].get_inputs()[0].name
+        action = self.ort_sessions["actor"].run(None, {actor_input_name: actor_input})[0]
+        action = action.reshape(-1)
+        
+        # Reconstruct full action including zeroed joints
+        mask = (self._zero_action_joints == 0).astype(bool)
+        full_action = np.zeros(self.ros_node.NUM_ACTIONS, dtype=np.float32)
+        full_action[mask] = action
+        
+        # Publish debug info
+        if self.debug_depth_publisher is not None:
+            depth_obs = (
+                self._get_depth_image_downsample_obs()
+                .reshape(-1, self.depth_height, self.depth_width)
+            )
+            depth_image_msg_data = np.asanyarray(
+                depth_obs[-1] * 255 * 2, dtype=np.uint16
+            )
+            depth_image_msg = rnp.msgify(Image, depth_image_msg_data, encoding="16UC1")
+            depth_image_msg.header.stamp = self.ros_node.get_clock().now().to_msg()
+            depth_image_msg.header.frame_id = "realsense_depth_link"
+            self.debug_depth_publisher.publish(depth_image_msg)
+        
+        if self.debug_pointcloud_publisher is not None and hasattr(self, "depth_range"):
+            depth_obs_raw = (
+                self._get_depth_image_downsample_obs()
+                .reshape(-1, self.depth_height, self.depth_width)[-1]
+            )
+            pointcloud_msg = self.ros_node.depth_image_to_pointcloud_msg(
+                depth_obs_raw * self.depth_range[1] + self.depth_range[0]
+            )
+            self.debug_pointcloud_publisher.publish(pointcloud_msg)
+        
+        return full_action, done
+
+    def get_cold_start_agent(
+        self,
+        startup_step_size: float = 0.2,
+        kpkd_factor: float = 2.0,
+    ) -> ColdStartAgent:
+        """Get a cold start agent configured with this agent's settings.
+        
+        Args:
+            startup_step_size: Step size for cold start
+            kpkd_factor: Factor to multiply P/D gains
+        
+        Returns:
+            ColdStartAgent configured for transition to this agent
+        """
+        return ColdStartAgent(
+            startup_step_size=startup_step_size,
+            ros_node=self.ros_node,
+            joint_target_pos=self.default_joint_pos,
+            action_scale=self.action_scale,
+            action_offset=self.action_offset,
+            p_gains=self.p_gains * kpkd_factor,
+            d_gains=self.d_gains * kpkd_factor,
+        )

--- a/instinct_onboard/agents/interaction_agent.py
+++ b/instinct_onboard/agents/interaction_agent.py
@@ -43,6 +43,37 @@ class InteractionAgent(PerceptiveTrackerAgent):
     EXPECTED_DEPTH_ENCODER_INPUT_SHAPE = [1, 1, 18, 32]
     EXPECTED_DEPTH_ENCODER_OUTPUT_DIM = 32
     EXPECTED_ACTOR_INPUT_DIM = 795
+    POLICY_JOINT_NAMES = [
+        "left_hip_pitch_joint",
+        "right_hip_pitch_joint",
+        "waist_yaw_joint",
+        "left_hip_roll_joint",
+        "right_hip_roll_joint",
+        "waist_roll_joint",
+        "left_hip_yaw_joint",
+        "right_hip_yaw_joint",
+        "waist_pitch_joint",
+        "left_knee_joint",
+        "right_knee_joint",
+        "left_shoulder_pitch_joint",
+        "right_shoulder_pitch_joint",
+        "left_ankle_pitch_joint",
+        "right_ankle_pitch_joint",
+        "left_shoulder_roll_joint",
+        "right_shoulder_roll_joint",
+        "left_ankle_roll_joint",
+        "right_ankle_roll_joint",
+        "left_shoulder_yaw_joint",
+        "right_shoulder_yaw_joint",
+        "left_elbow_joint",
+        "right_elbow_joint",
+        "left_wrist_roll_joint",
+        "right_wrist_roll_joint",
+        "left_wrist_pitch_joint",
+        "right_wrist_pitch_joint",
+        "left_wrist_yaw_joint",
+        "right_wrist_yaw_joint",
+    ]
 
     def __init__(
         self,
@@ -63,6 +94,9 @@ class InteractionAgent(PerceptiveTrackerAgent):
             pointcloud_vis=pointcloud_vis,
         )
         self._validate_sitting_policy_contract()
+
+    def _get_policy_joint_names(self) -> list[str]:
+        return list(self.POLICY_JOINT_NAMES)
 
     @classmethod
     def _validate_checkpoint_layout(cls, logdir: str) -> None:

--- a/instinct_onboard/agents/shadowing_agent.py
+++ b/instinct_onboard/agents/shadowing_agent.py
@@ -12,7 +12,7 @@ from geometry_msgs.msg import PoseArray
 from instinct_onboard.agents.base import OnboardAgent
 from instinct_onboard.ros_nodes.base import RealNode
 from instinct_onboard.utils import quat_to_tan_norm_batch
-from motion_target_msgs.msg import MotionSequence
+# from motion_target_msgs.msg import MotionSequence
 
 
 class ShadowingAgent(OnboardAgent):

--- a/instinct_onboard/agents/tracking_agent.py
+++ b/instinct_onboard/agents/tracking_agent.py
@@ -124,11 +124,15 @@ class TrackerAgent(OnboardAgent):
     def _load_all_motions(self, motion_file_dir: str):
         """Load the motion file."""
         self.all_motion_datas: dict[str, MotionData] = dict()
-        for motion_file in os.listdir(motion_file_dir):
+        for motion_file in sorted(os.listdir(motion_file_dir)):
+            if not motion_file.endswith(".npz"):
+                continue
             motion = load_motion_data(
                 os.path.join(motion_file_dir, motion_file), self.ros_node.sim_joint_names, self.target_motion_framerate
             )
             self.all_motion_datas[motion_file] = motion
+        if not self.all_motion_datas:
+            raise FileNotFoundError(f"No .npz motion files found in {motion_file_dir}")
         self.motion_data = list(self.all_motion_datas.values())[
             0
         ]  # put the first motion in the dictionary as the default motion

--- a/instinct_onboard/agents/tracking_agent.py
+++ b/instinct_onboard/agents/tracking_agent.py
@@ -245,8 +245,8 @@ class TrackerAgent(OnboardAgent):
             startup_step_size=startup_step_size,
             ros_node=self.ros_node,
             joint_target_pos=joint_target_pos,
-            action_scale=self.action_scale,  # Note: passing action_offset here sets _action_offset in ColdStartAgent due to parameter naming in init
-            action_offset=self.action_offset,  # passing action_scale here sets _action_scale
+            action_scale=self.action_scale,  # passing action_scale here sets _action_scale
+            action_offset=self.action_offset,  # passing action_offset here sets _action_offset in ColdStartAgent due to parameter naming in init
             p_gains=self.p_gains * kpkd_factor,
             d_gains=self.d_gains * kpkd_factor,
         )

--- a/instinct_onboard/agents/tracking_agent.py
+++ b/instinct_onboard/agents/tracking_agent.py
@@ -40,8 +40,42 @@ class TrackerAgent(OnboardAgent):
         self.ort_sessions: dict[str, ort.InferenceSession] = dict()
         self._parse_obs_config()
         self._parse_action_config()
+        self._configure_policy_joint_order()
         self._load_models()
         self._load_all_motions(motion_file_dir)
+
+    def _get_policy_joint_names(self) -> list[str]:
+        return list(self.ros_node.sim_joint_names)
+
+    def _configure_policy_joint_order(self) -> None:
+        self.policy_joint_names = self._get_policy_joint_names()
+        if len(self.policy_joint_names) != self.ros_node.NUM_JOINTS:
+            raise ValueError(
+                f"Policy joint order has {len(self.policy_joint_names)} joints, "
+                f"but robot has {self.ros_node.NUM_JOINTS}."
+            )
+        missing = set(self.policy_joint_names) - set(self.ros_node.sim_joint_names)
+        extra = set(self.ros_node.sim_joint_names) - set(self.policy_joint_names)
+        if missing or extra:
+            raise ValueError(
+                "Policy joint names must be the same set as onboard joint names. "
+                f"Missing from onboard: {sorted(missing)}; missing from policy: {sorted(extra)}."
+            )
+        self.policy_to_onboard_joint_ids = np.array(
+            [self.ros_node.sim_joint_names.index(joint_name) for joint_name in self.policy_joint_names],
+            dtype=np.int64,
+        )
+        self.default_joint_pos_policy = self._onboard_joint_array_to_policy_order(self.default_joint_pos)
+        self.default_joint_vel_policy = self._onboard_joint_array_to_policy_order(self.default_joint_vel)
+
+    def _onboard_joint_array_to_policy_order(self, values: np.ndarray) -> np.ndarray:
+        return np.asarray(values)[..., self.policy_to_onboard_joint_ids]
+
+    def _policy_joint_array_to_onboard_order(self, values: np.ndarray) -> np.ndarray:
+        values = np.asarray(values)
+        reordered = np.empty_like(values)
+        reordered[..., self.policy_to_onboard_joint_ids] = values
+        return reordered
 
     def _load_models(self):
         """Load the ONNX model for the agent."""
@@ -63,7 +97,7 @@ class TrackerAgent(OnboardAgent):
                 continue
             motion = load_motion_data(
                 os.path.join(motion_file_dir, motion_file),
-                self.ros_node.sim_joint_names,
+                self.policy_joint_names,
                 self.target_motion_framerate,
                 velocity_estimation_method=velocity_estimation_method,
             )
@@ -118,6 +152,7 @@ class TrackerAgent(OnboardAgent):
         actor_input_name = self.ort_sessions["actor"].get_inputs()[0].name
         action = self.ort_sessions["actor"].run(None, {actor_input_name: normalized_obs})[0]
         action = action.reshape(-1)
+        action = self._policy_joint_array_to_onboard_order(action)
         self.motion_cursor_idx += 1
         self.motion_cursor_idx = (
             self.motion_cursor_idx
@@ -154,7 +189,7 @@ class TrackerAgent(OnboardAgent):
     def _get_joint_pos_ref_command_cmd_obs(self):
         frame_indices = self.motion_frame_indices_offset + self.motion_cursor_idx
         frame_indices = frame_indices.clip(max=self.motion_data.total_num_frames - 1)
-        return self.motion_data.joint_pos[frame_indices] - self.default_joint_pos[None, :]
+        return self.motion_data.joint_pos[frame_indices] - self.default_joint_pos_policy[None, :]
 
     def _get_joint_vel_ref_command_cmd_obs(self):
         frame_indices = self.motion_frame_indices_offset + self.motion_cursor_idx
@@ -188,7 +223,7 @@ class TrackerAgent(OnboardAgent):
 
     def get_cold_start_agent(self, startup_step_size: float = 0.2, kpkd_factor: float = 1.0) -> ColdStartAgent:
         """Create a ColdStartAgent with joint_target_pos set to the 0-th frame of the motion."""
-        joint_target_pos = self.motion_data.joint_pos[0].copy()
+        joint_target_pos = self._policy_joint_array_to_onboard_order(self.motion_data.joint_pos[0]).copy()
         return ColdStartAgent(
             startup_step_size=startup_step_size,
             ros_node=self.ros_node,
@@ -198,6 +233,18 @@ class TrackerAgent(OnboardAgent):
             p_gains=self.p_gains * kpkd_factor,
             d_gains=self.d_gains * kpkd_factor,
         )
+
+    def _get_joint_pos_rel_obs(self) -> np.ndarray:
+        """Return joint positions in the policy joint order."""
+        return self._onboard_joint_array_to_policy_order(self.ros_node.joint_pos_) - self.default_joint_pos_policy
+
+    def _get_joint_vel_rel_obs(self) -> np.ndarray:
+        """Return joint velocities in the policy joint order."""
+        return self._onboard_joint_array_to_policy_order(self.ros_node.joint_vel_) - self.default_joint_vel_policy
+
+    def _get_last_action_obs(self) -> np.ndarray:
+        """Return last actions in the policy joint order."""
+        return self._onboard_joint_array_to_policy_order(self.ros_node.action)
 
 
 class PerceptiveTrackerAgent(TrackerAgent):
@@ -289,6 +336,7 @@ class PerceptiveTrackerAgent(TrackerAgent):
         actor_input_name = self.ort_sessions["actor"].get_inputs()[0].name
         action = self.ort_sessions["actor"].run(None, {actor_input_name: actor_input})[0]
         action = action.reshape(-1)
+        action = self._policy_joint_array_to_onboard_order(action)
         self.motion_cursor_idx += 1
         self.motion_cursor_idx = (
             self.motion_cursor_idx

--- a/instinct_onboard/agents/tracking_agent.py
+++ b/instinct_onboard/agents/tracking_agent.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import math
 import os
-from dataclasses import dataclass
-from typing import Dict, List
 
 import cv2
 import numpy as np
@@ -15,79 +12,15 @@ from sensor_msgs.msg import Image, PointCloud2, PointField
 from tf2_ros import StaticTransformBroadcaster
 
 from instinct_onboard.agents.base import ColdStartAgent, OnboardAgent
+from instinct_onboard.motion_utils import MotionData, load_motion_data
 from instinct_onboard.normalizer import Normalizer
 from instinct_onboard.ros_nodes.base import RealNode
 from instinct_onboard.utils import (
     inv_quat,
     quat_rotate_inverse,
-    quat_slerp_batch,
     quat_to_tan_norm_batch,
     yaw_quat,
 )
-
-
-@dataclass
-class MotionData:
-    framerate: float
-    # Joint orders must match the robot joint names in simulation order.
-    joint_pos: np.ndarray
-    joint_vel: np.ndarray
-    base_pos: np.ndarray
-    base_quat: np.ndarray
-    total_num_frames: int
-
-
-def load_motion_data(motion_file: str, robot_joint_names: list[str], target_framerate: float) -> MotionData:
-    motion_data = np.load(motion_file, allow_pickle=True)
-    framerate = motion_data["framerate"].item()
-
-    motion_joint_names_all = motion_data["joint_names"].tolist()
-    motion_joint_to_robot_joint_ids = [motion_joint_names_all.index(j_name) for j_name in robot_joint_names]
-
-    joint_pos = motion_data["joint_pos"][:, motion_joint_to_robot_joint_ids]
-    joint_pos_ = np.concatenate([joint_pos[0:1], joint_pos])
-    joint_vel = (joint_pos_[1:] - joint_pos_[:-1]) * framerate
-    base_pos = motion_data["base_pos_w"]
-    base_quat = motion_data["base_quat_w"]
-    total_num_frames = motion_data["joint_pos"].shape[0]
-
-    motion = MotionData(
-        framerate=framerate,
-        joint_pos=joint_pos,
-        joint_vel=joint_vel,
-        base_pos=base_pos,
-        base_quat=base_quat,
-        total_num_frames=total_num_frames,
-    )
-
-    return match_framerate(motion, target_framerate)
-
-
-def match_framerate(motion_data: MotionData, target_framerate: float) -> MotionData:
-    if motion_data.framerate == target_framerate:
-        return motion_data
-
-    motion_length_s = motion_data.total_num_frames / motion_data.framerate
-    new_total_num_frames = math.floor(motion_length_s * target_framerate)
-    new_frame_idxs = np.linspace(0, motion_data.total_num_frames - 1, new_total_num_frames)
-    floor = np.floor(new_frame_idxs).astype(int)
-    ceil = np.ceil(new_frame_idxs).astype(int)
-    frac = new_frame_idxs - floor
-
-    new_joint_pos = (1 - frac)[:, None] * motion_data.joint_pos[floor] + frac[:, None] * motion_data.joint_pos[ceil]
-    joint_pos_ = np.concatenate([new_joint_pos[0:1], new_joint_pos])
-    new_joint_vel = (joint_pos_[1:] - joint_pos_[:-1]) * target_framerate
-    new_base_pos = (1 - frac)[:, None] * motion_data.base_pos[floor] + frac[:, None] * motion_data.base_pos[ceil]
-    new_base_quat = quat_slerp_batch(motion_data.base_quat[floor], motion_data.base_quat[ceil], frac)
-
-    return MotionData(
-        framerate=target_framerate,
-        joint_pos=new_joint_pos.astype(np.float32),
-        joint_vel=new_joint_vel.astype(np.float32),
-        base_pos=new_base_pos.astype(np.float32),
-        base_quat=new_base_quat.astype(np.float32),
-        total_num_frames=new_total_num_frames,
-    )
 
 
 class TrackerAgent(OnboardAgent):
@@ -124,11 +57,15 @@ class TrackerAgent(OnboardAgent):
     def _load_all_motions(self, motion_file_dir: str):
         """Load the motion file."""
         self.all_motion_datas: dict[str, MotionData] = dict()
+        velocity_estimation_method = self._get_velocity_estimation_method()
         for motion_file in sorted(os.listdir(motion_file_dir)):
             if not motion_file.endswith(".npz"):
                 continue
             motion = load_motion_data(
-                os.path.join(motion_file_dir, motion_file), self.ros_node.sim_joint_names, self.target_motion_framerate
+                os.path.join(motion_file_dir, motion_file),
+                self.ros_node.sim_joint_names,
+                self.target_motion_framerate,
+                velocity_estimation_method=velocity_estimation_method,
             )
             self.all_motion_datas[motion_file] = motion
         if not self.all_motion_datas:
@@ -152,6 +89,13 @@ class TrackerAgent(OnboardAgent):
 
         self.motion_cursor_idx = 0
 
+    def _get_velocity_estimation_method(self):
+        motion_buffers = self.cfg["scene"]["motion_reference"].get("motion_buffers", {})
+        if len(motion_buffers) != 1:
+            return "backward"
+        motion_buffer_cfg = next(iter(motion_buffers.values()))
+        return motion_buffer_cfg.get("velocity_estimation_method", "backward")
+
     def reset(self, motion_name: str = None):
         """Reset the agent state and the rosbag reader."""
         super().reset()
@@ -168,18 +112,18 @@ class TrackerAgent(OnboardAgent):
 
     def step(self):
         """Perform a single step of the agent."""
-        self.motion_cursor_idx += 1
         done = self.get_done()
-        self.motion_cursor_idx = (
-            self.motion_cursor_idx
-            if self.motion_cursor_idx < self.motion_data.total_num_frames
-            else self.motion_data.total_num_frames - 1
-        )
         obs = self._get_observation()
         normalized_obs = self.normalizer.normalize(obs).astype(np.float32)[None, :]
         actor_input_name = self.ort_sessions["actor"].get_inputs()[0].name
         action = self.ort_sessions["actor"].run(None, {actor_input_name: normalized_obs})[0]
         action = action.reshape(-1)
+        self.motion_cursor_idx += 1
+        self.motion_cursor_idx = (
+            self.motion_cursor_idx
+            if self.motion_cursor_idx < self.motion_data.total_num_frames
+            else self.motion_data.total_num_frames - 1
+        )
         return action, done
 
     def match_to_current_heading(self):
@@ -324,13 +268,7 @@ class PerceptiveTrackerAgent(TrackerAgent):
             self.depth_image_slice = self._get_obs_slice("depth_image")
 
     def step(self):
-        self.motion_cursor_idx += 1
         done = self.get_done()
-        self.motion_cursor_idx = (
-            self.motion_cursor_idx
-            if self.motion_cursor_idx < self.motion_data.total_num_frames
-            else self.motion_data.total_num_frames - 1
-        )
         obs = self._get_observation()
         normalized_obs = self.normalizer.normalize(obs).astype(np.float32)[None, :]
         depth_image = normalized_obs[:, self.depth_image_slice].reshape(
@@ -351,6 +289,12 @@ class PerceptiveTrackerAgent(TrackerAgent):
         actor_input_name = self.ort_sessions["actor"].get_inputs()[0].name
         action = self.ort_sessions["actor"].run(None, {actor_input_name: actor_input})[0]
         action = action.reshape(-1)
+        self.motion_cursor_idx += 1
+        self.motion_cursor_idx = (
+            self.motion_cursor_idx
+            if self.motion_cursor_idx < self.motion_data.total_num_frames
+            else self.motion_data.total_num_frames - 1
+        )
 
         if self.debug_depth_publisher is not None:
             # NOTE: the +5.0 is a empirical value to ensure the normalized obs is not negative.

--- a/instinct_onboard/motion_utils.py
+++ b/instinct_onboard/motion_utils.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+
+VelocityEstimation = Literal["frontward", "backward", "frontbackward"]
+
+
+@dataclass
+class MotionData:
+    framerate: float
+    # Joint orders must match the robot joint names in simulation order.
+    joint_pos: np.ndarray
+    joint_vel: np.ndarray
+    base_pos: np.ndarray
+    base_quat: np.ndarray
+    total_num_frames: int
+
+
+def estimate_velocity_np(
+    positions: np.ndarray,
+    dt: float,
+    estimation_type: VelocityEstimation | None = "backward",
+) -> np.ndarray:
+    if estimation_type is None:
+        return np.zeros_like(positions, dtype=np.float32)
+    if estimation_type == "frontward":
+        next_frame = np.roll(positions, -1, axis=0)
+        next_frame[-1] = positions[-1]
+        prev_frame = positions
+        velocity = (next_frame - prev_frame) / dt
+    elif estimation_type == "backward":
+        prev_frame = np.roll(positions, 1, axis=0)
+        prev_frame[0] = positions[0]
+        next_frame = positions
+        velocity = (next_frame - prev_frame) / dt
+    elif estimation_type == "frontbackward":
+        prev_frame = np.roll(positions, 1, axis=0)
+        prev_frame[0] = positions[0]
+        next_frame = np.roll(positions, -1, axis=0)
+        next_frame[-1] = positions[-1]
+        velocity = (next_frame - prev_frame) / (2.0 * dt)
+    else:
+        raise ValueError(f"Unknown velocity estimation type: {estimation_type}")
+    return velocity.astype(np.float32)
+
+
+def quat_slerp_batch_np(q1: np.ndarray, q2: np.ndarray, tau: np.ndarray) -> np.ndarray:
+    assert q1.shape[-1] == 4, "The quaternion must be in (w, x, y, z) format."
+    assert q2.shape[-1] == 4, "The quaternion must be in (w, x, y, z) format."
+    assert tau.shape == q1.shape[:-1], "The batch size must be the same for all inputs."
+
+    q1 = q1.astype(np.float32)
+    q2 = q2.astype(np.float32)
+    tau = tau.astype(np.float32)
+
+    dot_product = np.sum(q1 * q2, axis=-1, keepdims=True).clip(-1.0, 1.0)
+    q2 = np.where(dot_product < 0.0, -q2, q2)
+    dot_product = np.where(dot_product < 0.0, -dot_product, dot_product)
+
+    theta = np.arccos(dot_product)
+    sin_theta = np.sin(theta)
+    q_too_similar = (dot_product > (1.0 - 1e-9)) | (np.abs(theta) < 1e-9)
+    sin_theta = np.where(np.abs(sin_theta) < 1e-9, np.ones_like(sin_theta), sin_theta)
+
+    s1 = np.sin((1.0 - tau)[:, None] * theta) / sin_theta
+    s2 = np.sin(tau[:, None] * theta) / sin_theta
+    interpolated_quat = (s1 * q1 + s2 * q2) * (~q_too_similar) + q_too_similar * q1
+    interpolated_quat = interpolated_quat / np.linalg.norm(interpolated_quat, axis=-1, keepdims=True).clip(min=1e-6)
+    return interpolated_quat.astype(np.float32)
+
+
+def load_motion_data(
+    motion_file: str,
+    robot_joint_names: list[str],
+    target_framerate: float,
+    velocity_estimation_method: VelocityEstimation | None = "backward",
+) -> MotionData:
+    motion_data = np.load(motion_file, allow_pickle=True)
+    framerate = motion_data["framerate"].item()
+
+    motion_joint_names_all = motion_data["joint_names"].tolist()
+    motion_joint_to_robot_joint_ids = [motion_joint_names_all.index(j_name) for j_name in robot_joint_names]
+
+    joint_pos = motion_data["joint_pos"][:, motion_joint_to_robot_joint_ids]
+    joint_vel = estimate_velocity_np(joint_pos, 1.0 / framerate, velocity_estimation_method)
+    base_pos = motion_data["base_pos_w"]
+    base_quat = motion_data["base_quat_w"]
+    total_num_frames = motion_data["joint_pos"].shape[0]
+
+    motion = MotionData(
+        framerate=framerate,
+        joint_pos=joint_pos.astype(np.float32),
+        joint_vel=joint_vel.astype(np.float32),
+        base_pos=base_pos.astype(np.float32),
+        base_quat=base_quat.astype(np.float32),
+        total_num_frames=total_num_frames,
+    )
+
+    return match_framerate(motion, target_framerate, velocity_estimation_method)
+
+
+def match_framerate(
+    motion_data: MotionData,
+    target_framerate: float,
+    velocity_estimation_method: VelocityEstimation | None = "backward",
+) -> MotionData:
+    if motion_data.framerate == target_framerate:
+        return motion_data
+
+    motion_length_s = motion_data.total_num_frames / motion_data.framerate
+    new_total_num_frames = math.floor(motion_length_s * target_framerate)
+    new_frame_idxs = np.linspace(0, motion_data.total_num_frames - 1, new_total_num_frames)
+    floor = np.floor(new_frame_idxs).astype(int)
+    ceil = np.ceil(new_frame_idxs).astype(int)
+    frac = new_frame_idxs - floor
+
+    new_joint_pos = (1.0 - frac)[:, None] * motion_data.joint_pos[floor] + frac[:, None] * motion_data.joint_pos[ceil]
+    new_joint_vel = estimate_velocity_np(new_joint_pos, 1.0 / target_framerate, velocity_estimation_method)
+    new_base_pos = (1.0 - frac)[:, None] * motion_data.base_pos[floor] + frac[:, None] * motion_data.base_pos[ceil]
+    new_base_quat = quat_slerp_batch_np(motion_data.base_quat[floor], motion_data.base_quat[ceil], frac)
+
+    return MotionData(
+        framerate=target_framerate,
+        joint_pos=new_joint_pos.astype(np.float32),
+        joint_vel=new_joint_vel.astype(np.float32),
+        base_pos=new_base_pos.astype(np.float32),
+        base_quat=new_base_quat.astype(np.float32),
+        total_num_frames=new_total_num_frames,
+    )

--- a/instinct_onboard/ros_nodes/base.py
+++ b/instinct_onboard/ros_nodes/base.py
@@ -207,16 +207,15 @@ class RealNode(Node):
         NOTE: when switching between agents, the last_action term should be shared between agents.
         Thus, the ros node has to update the action buffer
         """
-        # NOTE: Only calling this function currently will update self.actions for self._get_last_action_obs
+        if np.isnan(action).any():
+            self.get_logger().error("Actions contain NaN, Skip sending the action to the robot.")
+            return
         self.action[:] = action
         self.action_publisher.publish(Float32MultiArray(data=action))
         action_scaled = action * action_scale
         target_joint_pos = action_scaled + action_offset
         p_gains = np.clip(p_gains * self.kp_factor, 0.0, self.kp_clip)
         d_gains = np.clip(d_gains * self.kd_factor, 0.0, self.kd_clip)
-        if np.isnan(action).any():
-            self.get_logger().error("Actions contain NaN, Skip sending the action to the robot.")
-            return
         if self.computer_clip_torque:
             target_joint_pos = self.clip_by_torque_limit(
                 target_joint_pos,

--- a/instinct_onboard/ros_nodes/base.py
+++ b/instinct_onboard/ros_nodes/base.py
@@ -224,6 +224,10 @@ class RealNode(Node):
             )
         self._publish_motor_cmd(target_joint_pos, p_gains=p_gains, d_gains=d_gains)
 
+    def clear_action_buffer(self):
+        """Clear last-action observations without sending any motor command."""
+        self.action[:] = 0.0
+
     @abstractmethod
     def _publish_motor_cmd(self, target_joint_pos: np.array, p_gains: np.array, d_gains: np.array):
         """Publish the joint commands to the robot motors in robot coordinates system.

--- a/instinct_onboard/ros_nodes/unitree.py
+++ b/instinct_onboard/ros_nodes/unitree.py
@@ -209,6 +209,9 @@ class UnitreeNode(RealNode):
         """Publish the joint commands to the robot motors in robot coordinates system.
         robot_coordinates_action: shape (NUM_JOINTS,), in simulation order.
         """
+        if np.isnan(target_joint_pos).any():
+            self.get_logger().error("Robot coordinates action contain NaN, Skip sending the action to the robot.")
+            return
         for sim_idx in range(self.NUM_JOINTS):
             real_idx = self.joint_map[sim_idx]
             if not self.dryrun:
@@ -220,9 +223,6 @@ class UnitreeNode(RealNode):
             self.low_cmd_buffer.motor_cmd[real_idx].kd = d_gains[sim_idx].item()
 
         self.low_cmd_buffer.crc = get_crc(self.low_cmd_buffer)
-        if np.isnan(target_joint_pos).any():
-            self.get_logger().error("Robot coordinates action contain NaN, Skip sending the action to the robot.")
-            return
         self.low_cmd_publisher.publish(self.low_cmd_buffer)
 
     def _turn_off_motors(self):

--- a/instinct_onboard/ros_nodes/unitree.py
+++ b/instinct_onboard/ros_nodes/unitree.py
@@ -150,7 +150,9 @@ class UnitreeNode(RealNode):
         if (msg.keys & robot_cfgs.UnitreeWirelessButtons.R2) or (
             msg.keys & robot_cfgs.UnitreeWirelessButtons.L2
         ):  # R2 or L2 is pressed
-            self.get_logger().warn("R2 or L2 is pressed, the motors and this process shuts down.")
+            self.get_logger().warn(
+                f"R2 or L2 is pressed (keys=0x{msg.keys:04x}), the motors and this process shuts down."
+            )
             self._turn_off_motors()
             raise SystemExit()
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,11 +27,10 @@ Basic motion tracking from NPZ files (no depth perception).
 - **Usage**: `python g1_track.py --logdir /path/to/tracking/model --motion_dir /path/to/motions`
 
 ### g1_interaction.py
-Object interaction task with depth perception, motion reference, and object state tracking.
+Interaction task deployed from the sitting checkpoint truth.
 - **Agent**: InteractionAgent + WalkAgent
-- **Features**: Depth perception, motion reference, object position/orientation observations, contact force sensing
+- **Features**: Raw observation normalization, depth encoder, actor inference, motion reference tracking
 - **Usage**: `python g1_interaction.py --logdir /path/to/interaction/model --walk_logdir /path/to/walk/model --motion_dir /path/to/motions`
-- **Notes**: Object-related observations (object_pos, object_ori, wrist_object_contact) currently return zeros until motion data with object trajectories is provided
 
 ## Common Arguments
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,3 +5,48 @@ This is the directory storing all entry-points of the Instinct Onboard repositor
 Please DO NOT import any of the python files in this directory from other modules.
 
 **The scripts in this directory are meant to be run as standalone programs.**
+
+## Available Scripts
+
+### g1_parkour.py
+Autonomous parkour behaviors using depth camera perception.
+- **Agent**: ParkourAgent + ParkourStandAgent
+- **Features**: Depth perception, terrain navigation, velocity control
+- **Usage**: `python g1_parkour.py --logdir /path/to/parkour/model --standdir /path/to/stand/model`
+
+### g1_perceptive_track.py
+Perceptive motion tracking with depth camera and NPZ motion files.
+- **Agent**: PerceptiveTrackerAgent + WalkAgent
+- **Features**: Depth perception, motion reference tracking, walk mode
+- **Usage**: `python g1_perceptive_track.py --logdir /path/to/tracking/model --motion_dir /path/to/motions`
+
+### g1_track.py
+Basic motion tracking from NPZ files (no depth perception).
+- **Agent**: TrackerAgent
+- **Features**: Motion reference from files, simple tracking
+- **Usage**: `python g1_track.py --logdir /path/to/tracking/model --motion_dir /path/to/motions`
+
+### g1_interaction.py
+Object interaction task with depth perception, motion reference, and object state tracking.
+- **Agent**: InteractionAgent + WalkAgent
+- **Features**: Depth perception, motion reference, object position/orientation observations, contact force sensing
+- **Usage**: `python g1_interaction.py --logdir /path/to/interaction/model --walk_logdir /path/to/walk/model --motion_dir /path/to/motions`
+- **Notes**: Object-related observations (object_pos, object_ori, wrist_object_contact) currently return zeros until motion data with object trajectories is provided
+
+## Common Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--logdir` | Directory containing exported ONNX model and configs |
+| `--nodryrun` | Disable dry run mode (enables actual robot control) |
+| `--startup_step_size` | Cold start step size (default: 0.2) |
+| `--kpkd_factor` | KP/KD gain multiplier for cold start (default: 2.0) |
+| `--debug` | Enable debugpy for remote debugging |
+
+## Visualization Options
+
+| Argument | Description |
+|----------|-------------|
+| `--depth_vis` | Publish depth images to `/debug/depth_image` |
+| `--pointcloud_vis` | Publish point clouds to `/debug/pointcloud` |
+| `--motion_vis` | Publish motion sequence as JointState for RViz |

--- a/scripts/g1_interaction.py
+++ b/scripts/g1_interaction.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""
+G1 Interaction Node - One-click script for interaction task deployment.
+
+A ROS2 node for controlling Unitree G1 robot using interaction agent with depth camera
+perception and object state tracking. This script integrates RealSense camera for depth-based
+perception, motion reference tracking from NPZ files, and object state observation.
+
+Features:
+    - Depth perception using RealSense D435 camera
+    - InteractionAgent with depth image encoding and motion reference
+    - Object state observations (position, orientation, contact forces)
+    - Multiple agent modes: cold start, walk, and interaction
+    - Real-time motion tracking with joystick control
+    - Visualization options for debugging
+
+Command-Line Arguments:
+    Required:
+        --logdir PATH          Directory containing the trained interaction agent model
+                              (must contain exported/actor.onnx and exported/0-depth_encoder.onnx)
+        --walk_logdir PATH    Directory containing the walk agent model
+        --motion_dir PATH     Directory containing retargeted motion files (.npz format)
+
+    Optional:
+        --startup_step_size FLOAT
+                              Startup step size for cold start agent (default: 0.2)
+        --nodryrun           Disable dry run mode (default: False, runs in dry run mode)
+        --kpkd_factor FLOAT  KP/KD gain multiplier for cold start agent (default: 2.0)
+        --depth_vis          Enable depth image visualization (publishes to /debug/depth_image)
+        --pointcloud_vis     Enable pointcloud visualization (publishes to /debug/pointcloud)
+        --motion_vis         Enable motion visualization by publishing joint states and TF
+        --debug              Enable debug mode with debugpy (listens on 0.0.0.0:6789)
+
+Agent Workflow:
+    1. Cold Start Agent (initial state)
+       - Automatically starts when node launches
+       - Transitions robot to initial pose using walk agent's default configuration
+       - Press 'L1' to switch to walk agent (if available)
+       - Press any direction button to switch to interaction agent
+
+    2. Walk Agent
+       - Activated by pressing 'L1' after cold start completes
+       - Provides basic walking behavior
+       - Press direction buttons to switch to interaction agent with specific motions:
+         * UP:    First motion file in directory
+         * DOWN:  Second motion file (if available)
+         * LEFT/RIGHT: Alternative motions (if available)
+       - Press 'L1' from interaction agent to return to walk agent
+
+    3. Interaction Agent
+       - Executes interaction motions with depth perception and object tracking
+       - Press 'A' button to match motion to current robot heading
+       - Automatically switches to walk agent when motion completes (if available)
+       - Otherwise turns off motors and exits
+
+Joystick Controls:
+    A Button:     Match interaction motion to current robot heading
+    L1 Button:    Switch between walk and interaction agents
+    Direction Buttons: Switch to interaction agent with specific motion files
+
+Example Usage:
+    Basic usage with required arguments:
+        python g1_interaction.py \
+            --logdir /path/to/interaction/model \
+            --walk_logdir /path/to/walk/model \
+            --motion_dir /path/to/motions
+
+    With visualization options:
+        python g1_interaction.py \
+            --logdir /path/to/interaction/model \
+            --walk_logdir /path/to/walk/model \
+            --motion_dir /path/to/motions \
+            --depth_vis --pointcloud_vis --motion_vis
+
+    Dry run mode (default, no actual robot control):
+        python g1_interaction.py \
+            --logdir /path/to/interaction/model \
+            --walk_logdir /path/to/walk/model \
+            --motion_dir /path/to/motions
+
+    Real robot control (disable dry run):
+        python g1_interaction.py \
+            --logdir /path/to/interaction/model \
+            --walk_logdir /path/to/walk/model \
+            --motion_dir /path/to/motions \
+            --nodryrun
+
+    With custom startup parameters:
+        python g1_interaction.py \
+            --logdir /path/to/interaction/model \
+            --walk_logdir /path/to/walk/model \
+            --motion_dir /path/to/motions \
+            --startup_step_size 0.3 \
+            --kpkd_factor 1.5
+
+Notes:
+    - The script runs at 50Hz main loop frequency (20ms period)
+    - RealSense camera is configured at 480x270 resolution, 60 FPS
+    - Robot configuration: G1_29Dof_TorsoBase (29 degrees of freedom)
+    - Joint position protection ratio: 2.0
+    - Camera runs in a separate process for better performance
+    - Motion data with object trajectories is currently not yet available;
+      object-related observations return zeros until data is provided
+"""
+
+import os
+import queue
+import sys
+import time
+
+import numpy as np
+import rclpy
+from geometry_msgs.msg import TransformStamped
+from sensor_msgs.msg import JointState
+from tf2_ros import TransformBroadcaster
+
+from instinct_onboard.agents.base import ColdStartAgent
+from instinct_onboard.agents.interaction_agent import InteractionAgent
+from instinct_onboard.agents.walk_agent import WalkAgent
+from instinct_onboard.ros_nodes.realsense import UnitreeRsCameraNode
+
+MAIN_LOOP_FREQUENCY_CHECK_INTERVAL = 500
+
+
+class G1InteractionNode(UnitreeRsCameraNode):
+    """ROS2 node for G1 interaction task.
+    
+    This node manages multiple agents for the interaction workflow:
+    - cold_start: Initial pose transition
+    - walk: Basic walking behavior
+    - interaction: Object manipulation with motion reference and depth perception
+    
+    The node handles agent switching based on joystick input and motion completion.
+    """
+
+    def __init__(
+        self,
+        *args,
+        motion_vis: bool = False,
+        **kwargs,
+    ):
+        """Initialize the G1 interaction node.
+        
+        Args:
+            *args: Positional arguments passed to parent UnitreeRsCameraNode
+            motion_vis: Whether to visualize motion sequences
+            **kwargs: Keyword arguments passed to parent UnitreeRsCameraNode
+        """
+        super().__init__(*args, **kwargs)
+        self.available_agents = dict()
+        self.current_agent_name: str | None = None
+        self.motion_vis = motion_vis
+        self._motion_file_list = []  # List of available motion files
+
+    def register_agent(self, name: str, agent):
+        """Register an agent with the node.
+        
+        Args:
+            name: Agent name identifier
+            agent: Agent instance
+        """
+        self.available_agents[name] = agent
+        
+        # Build motion file list for interaction agent
+        if name == "interaction" and hasattr(agent, "all_motion_datas"):
+            self._motion_file_list = list(agent.all_motion_datas.keys())
+            self.get_logger().info(f"Available interaction motions: {self._motion_file_list}")
+
+    def start_ros_handlers(self):
+        """Start ROS handlers including publishers and timers."""
+        super().start_ros_handlers()
+        
+        # Create joint state publisher for motion visualization
+        self.joint_state_publisher = self.create_publisher(JointState, "joint_states", 10)
+        self.tf_broadcaster = TransformBroadcaster(self)
+        
+        # Start main loop timer at 50Hz (20ms period)
+        main_loop_duration = 0.02
+        self.get_logger().info(f"Starting main loop with duration: {main_loop_duration} seconds.")
+        self.main_loop_timer = self.create_timer(main_loop_duration, self.main_loop_callback)
+        
+        # Performance monitoring
+        if MAIN_LOOP_FREQUENCY_CHECK_INTERVAL > 1:
+            self.main_loop_timer_counter: int = 0
+            self.main_loop_timer_counter_time = time.time()
+            self.main_loop_callback_time_consumptions = queue.Queue(
+                maxsize=MAIN_LOOP_FREQUENCY_CHECK_INTERVAL
+            )
+        
+        # Motion visualization timer at 10Hz (100ms period)
+        if self.motion_vis:
+            self.vis_timer = self.create_timer(0.1, self.vis_callback)
+
+    def main_loop_callback(self):
+        """Main control loop executed at 50Hz.
+        
+        This callback implements the state machine for agent switching:
+        - cold_start: Initial pose, transitions to walk/interaction on button press
+        - walk: Basic walking, transitions to interaction on direction button
+        - interaction: Motion execution, transitions to walk on L1 or on completion
+        """
+        main_loop_callback_start_time = time.time()
+        
+        # Auto-start cold start agent if no agent is active
+        if self.current_agent_name is None:
+            self.get_logger().info("Starting cold start agent automatically.")
+            self.get_logger().info(
+                "Press 'L1' to switch to walk agent, or direction buttons for interaction.",
+                throttle_duration_sec=2.0,
+            )
+            self.current_agent_name = "cold_start"
+            self.available_agents[self.current_agent_name].reset()
+            return
+
+        # Handle cold start agent
+        elif self.current_agent_name == "cold_start":
+            action, done = self.available_agents[self.current_agent_name].step()
+            
+            if done:
+                if "walk" in self.available_agents:
+                    self.get_logger().info(
+                        "ColdStartAgent done, press 'L1' to switch to walk agent.",
+                        throttle_duration_sec=10.0,
+                    )
+                else:
+                    self.get_logger().info(
+                        "ColdStartAgent done, press direction buttons to switch to interaction agent.",
+                        throttle_duration_sec=10.0,
+                    )
+            
+            self.send_action(
+                action,
+                self.available_agents[self.current_agent_name].action_offset,
+                self.available_agents[self.current_agent_name].action_scale,
+                self.available_agents[self.current_agent_name].p_gains,
+                self.available_agents[self.current_agent_name].d_gains,
+            )
+            
+            # Switch to walk on L1 button
+            if done and self.joy_stick_data.L1 and "walk" in self.available_agents:
+                self.get_logger().info("L1 button pressed, switching to walk agent.")
+                self.current_agent_name = "walk"
+                self.available_agents[self.current_agent_name].reset()
+            
+            # Switch to interaction on direction buttons (if no walk agent)
+            if done and not self.joy_stick_data.L1:
+                if self.joy_stick_data.up and "interaction" in self.available_agents:
+                    self._switch_to_interaction_motion(0)  # First motion
+                elif self.joy_stick_data.down and "interaction" in self.available_agents:
+                    self._switch_to_interaction_motion(1)  # Second motion
+                elif self.joy_stick_data.left and "interaction" in self.available_agents:
+                    self._switch_to_interaction_motion(2)  # Third motion
+                elif self.joy_stick_data.right and "interaction" in self.available_agents:
+                    self._switch_to_interaction_motion(3)  # Fourth motion
+
+        # Handle walk agent
+        elif self.current_agent_name == "walk":
+            action, done = self.available_agents[self.current_agent_name].step()
+            self.send_action(
+                action,
+                self.available_agents[self.current_agent_name].action_offset,
+                self.available_agents[self.current_agent_name].action_scale,
+                self.available_agents[self.current_agent_name].p_gains,
+                self.available_agents[self.current_agent_name].d_gains,
+            )
+            
+            # Switch to interaction on direction buttons
+            if self.joy_stick_data.up and "interaction" in self.available_agents:
+                self.get_logger().info("UP button pressed, switching to interaction agent.")
+                self._switch_to_interaction_motion(0)
+            elif self.joy_stick_data.down and "interaction" in self.available_agents:
+                self.get_logger().info("DOWN button pressed, switching to interaction agent.")
+                self._switch_to_interaction_motion(1)
+            elif self.joy_stick_data.left and "interaction" in self.available_agents:
+                self.get_logger().info("LEFT button pressed, switching to interaction agent.")
+                self._switch_to_interaction_motion(2)
+            elif self.joy_stick_data.right and "interaction" in self.available_agents:
+                self.get_logger().info("RIGHT button pressed, switching to interaction agent.")
+                self._switch_to_interaction_motion(3)
+
+        # Handle interaction agent
+        elif self.current_agent_name == "interaction":
+            action, done = self.available_agents[self.current_agent_name].step()
+            self.send_action(
+                action,
+                self.available_agents[self.current_agent_name].action_offset,
+                self.available_agents[self.current_agent_name].action_scale,
+                self.available_agents[self.current_agent_name].p_gains,
+                self.available_agents[self.current_agent_name].d_gains,
+            )
+            
+            # Match motion to current heading on A button
+            if self.joy_stick_data.A:
+                self.get_logger().info(
+                    "A button pressed, matching motion to current heading.",
+                    throttle_duration_sec=2.0,
+                )
+                self.available_agents["interaction"].match_to_current_heading()
+            
+            # Switch to walk on L1 button
+            if self.joy_stick_data.L1:
+                self.get_logger().info("L1 button pressed, switching to walk agent.")
+                self.current_agent_name = "walk"
+                self.available_agents[self.current_agent_name].reset()
+            
+            # Handle motion completion
+            if done:
+                if "walk" in self.available_agents:
+                    self.get_logger().info("Interaction motion done, switching to walk agent.")
+                    self.current_agent_name = "walk"
+                    self.available_agents[self.current_agent_name].reset()
+                else:
+                    self.get_logger().info("Interaction motion done, turning off motors.")
+                    self._turn_off_motors()
+                    sys.exit(0)
+
+        # Log actual frequency every 500 cycles
+        if MAIN_LOOP_FREQUENCY_CHECK_INTERVAL > 1:
+            self.main_loop_callback_time_consumptions.put(
+                time.time() - main_loop_callback_start_time
+            )
+            self.main_loop_timer_counter += 1
+            if self.main_loop_timer_counter % MAIN_LOOP_FREQUENCY_CHECK_INTERVAL == 0:
+                time_consumptions = [
+                    self.main_loop_callback_time_consumptions.get()
+                    for _ in range(MAIN_LOOP_FREQUENCY_CHECK_INTERVAL)
+                ]
+                self.get_logger().info(
+                    f"Actual main loop frequency: "
+                    f"{(MAIN_LOOP_FREQUENCY_CHECK_INTERVAL / (time.time() - self.main_loop_timer_counter_time)):.2f} Hz. "
+                    f"Mean time consumption: {np.mean(time_consumptions):.4f} s."
+                )
+                self.main_loop_timer_counter = 0
+                self.main_loop_timer_counter_time = time.time()
+
+    def _switch_to_interaction_motion(self, motion_index: int):
+        """Switch to interaction agent with specified motion.
+        
+        Args:
+            motion_index: Index into the available motion file list
+        """
+        if motion_index < len(self._motion_file_list):
+            motion_name = self._motion_file_list[motion_index]
+            self.get_logger().info(f"Switching to interaction with motion: {motion_name}")
+        else:
+            motion_name = None
+            self.get_logger().warn(
+                f"Motion index {motion_index} out of range, using default motion"
+            )
+        
+        self.current_agent_name = "interaction"
+        self.available_agents[self.current_agent_name].reset(motion_name)
+
+    def vis_callback(self):
+        """Visualization callback for publishing motion sequence as JointState.
+        
+        This is called at 10Hz to publish the target motion's joint states
+        for visualization in rviz or similar tools.
+        """
+        if "interaction" not in self.available_agents:
+            return
+        
+        agent: InteractionAgent = self.available_agents["interaction"]
+        
+        if agent.motion_data is None:
+            return
+        
+        cursor = min(agent.motion_cursor_idx, agent.motion_data.total_num_frames - 1)
+        
+        # Publish JointState for target joints
+        js = JointState()
+        js.header.stamp = self.get_clock().now().to_msg()
+        js.name = self.sim_joint_names
+        joint_pos = agent.motion_data.joint_pos[cursor]
+        joint_vel = agent.motion_data.joint_vel[cursor]
+        js.position = joint_pos.tolist()
+        js.velocity = joint_vel.tolist()
+        js.effort = [0.0] * len(joint_pos)
+        self.joint_state_publisher.publish(js)
+        
+        # Broadcast TF for target base
+        pos = agent.motion_data.base_pos[cursor]
+        quat = agent.motion_data.base_quat[cursor]
+        t = TransformStamped()
+        t.header.stamp = js.header.stamp
+        t.header.frame_id = "world"
+        t.child_frame_id = "torso_link"
+        t.transform.translation.x = float(pos[0])
+        t.transform.translation.y = float(pos[1])
+        t.transform.translation.z = float(pos[2])
+        t.transform.rotation.w = float(quat[0])
+        t.transform.rotation.x = float(quat[1])
+        t.transform.rotation.y = float(quat[2])
+        t.transform.rotation.z = float(quat[3])
+        self.tf_broadcaster.sendTransform(t)
+
+
+def main(args):
+    """Main entry point for the G1 interaction node."""
+    rclpy.init()
+
+    node = G1InteractionNode(
+        rs_resolution=(480, 270),  # (width, height)
+        rs_fps=60,
+        camera_individual_process=True,
+        joint_pos_protect_ratio=2.0,
+        robot_class_name="G1_29Dof_TorsoBase",
+        motion_vis=args.motion_vis,
+        dryrun=not args.nodryrun,
+    )
+
+    # Create walk agent
+    walk_agent = WalkAgent(
+        logdir=args.walk_logdir,
+        ros_node=node,
+    )
+    node.register_agent("walk", walk_agent)
+
+    # Create interaction agent
+    interaction_agent = InteractionAgent(
+        logdir=args.logdir,
+        motion_file_dir=args.motion_dir,
+        ros_node=node,
+        depth_vis=args.depth_vis,
+        pointcloud_vis=args.pointcloud_vis,
+    )
+    node.register_agent("interaction", interaction_agent)
+
+    # Create cold start agent using walk agent's configuration
+    cold_start_agent = ColdStartAgent(
+        startup_step_size=args.startup_step_size,
+        ros_node=node,
+        joint_target_pos=walk_agent.default_joint_pos,
+        action_scale=walk_agent.action_scale,
+        action_offset=walk_agent.action_offset,
+        p_gains=walk_agent.p_gains * args.kpkd_factor,
+        d_gains=walk_agent.d_gains * args.kpkd_factor,
+    )
+    node.register_agent("cold_start", cold_start_agent)
+
+    # Publish static transforms for visualization
+    if args.depth_vis or args.pointcloud_vis:
+        node.publish_auxiliary_static_transforms("realsense_depth_link_transform")
+
+    node.start_ros_handlers()
+    node.get_logger().info("G1InteractionNode is ready to run.")
+    
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        print("Keyboard interrupt received, shutting down...")
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+        print("Node shutdown complete.")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="G1 Interaction Node - Interaction task with depth perception and object tracking"
+    )
+    
+    # Required arguments
+    parser.add_argument(
+        "--logdir",
+        type=str,
+        required=True,
+        help="Directory to load the interaction agent from (must contain exported/actor.onnx)",
+    )
+    parser.add_argument(
+        "--walk_logdir",
+        type=str,
+        required=True,
+        help="Directory to load the walk agent from (must contain exported/actor.onnx)",
+    )
+    parser.add_argument(
+        "--motion_dir",
+        type=str,
+        required=True,
+        help="Directory containing motion files (.npz format)",
+    )
+    
+    # Optional arguments
+    parser.add_argument(
+        "--startup_step_size",
+        type=float,
+        default=0.2,
+        help="Startup step size for the cold start agent (default: 0.2)",
+    )
+    parser.add_argument(
+        "--kpkd_factor",
+        type=float,
+        default=2.0,
+        help="KPKD factor for the cold start agent (default: 2.0)",
+    )
+    parser.add_argument(
+        "--nodryrun",
+        action="store_true",
+        default=False,
+        help="Run the node without dry run mode (default: False)",
+    )
+    parser.add_argument(
+        "--depth_vis",
+        action="store_true",
+        default=False,
+        help="Visualize the depth image (default: False)",
+    )
+    parser.add_argument(
+        "--pointcloud_vis",
+        action="store_true",
+        default=False,
+        help="Visualize the pointcloud (default: False)",
+    )
+    parser.add_argument(
+        "--motion_vis",
+        action="store_true",
+        default=False,
+        help="Visualize the motion sequence by publishing joint states and TF (default: False)",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Enable debug mode with debugpy (default: False)",
+    )
+
+    args = parser.parse_args()
+
+    # Enable debugpy if requested
+    if args.debug:
+        import debugpy
+
+        ip_address = ("0.0.0.0", 6789)
+        print("Process: " + " ".join(sys.argv[:]))
+        print(f"Is waiting for attach at address: {ip_address[0]}:{ip_address[1]}", flush=True)
+        debugpy.listen(ip_address)
+        debugpy.wait_for_client()
+        debugpy.breakpoint()
+
+    main(args)

--- a/scripts/g1_interaction.py
+++ b/scripts/g1_interaction.py
@@ -1,23 +1,25 @@
 #!/usr/bin/env python3
 """
-G1 Interaction Node - One-click script for interaction task deployment.
+G1 Interaction Node aligned with the sitting interaction checkpoint.
 
-A ROS2 node for controlling Unitree G1 robot using interaction agent with depth camera
-perception and object state tracking. This script integrates RealSense camera for depth-based
-perception, motion reference tracking from NPZ files, and object state observation.
+This script treats `interaction` as the sitting-updated version of the same task.
+The onboard policy therefore follows the exported sitting deployment contract:
+
+    raw policy obs -> policy normalizer -> depth slice -> 0-depth_image.onnx -> actor.onnx
 
 Features:
     - Depth perception using RealSense D435 camera
-    - InteractionAgent with depth image encoding and motion reference
-    - Object state observations (position, orientation, contact forces)
+    - InteractionAgent backed by the sitting truth checkpoint
+    - Motion reference tracking from NPZ files
     - Multiple agent modes: cold start, walk, and interaction
-    - Real-time motion tracking with joystick control
     - Visualization options for debugging
 
 Command-Line Arguments:
     Required:
-        --logdir PATH          Directory containing the trained interaction agent model
-                              (must contain exported/actor.onnx and exported/0-depth_encoder.onnx)
+        --logdir PATH          Directory containing the sitting-aligned interaction export
+                              (must contain params/env.yaml, params/agent.yaml,
+                              exported/actor.onnx, exported/0-depth_image.onnx,
+                              exported/policy_normalizer.npz)
         --walk_logdir PATH    Directory containing the walk agent model
         --motion_dir PATH     Directory containing retargeted motion files (.npz format)
 
@@ -48,7 +50,7 @@ Agent Workflow:
        - Press 'L1' from interaction agent to return to walk agent
 
     3. Interaction Agent
-       - Executes interaction motions with depth perception and object tracking
+       - Executes interaction motions with sitting-truth observations
        - Press 'A' button to match motion to current robot heading
        - Automatically switches to walk agent when motion completes (if available)
        - Otherwise turns off motors and exits
@@ -99,8 +101,8 @@ Notes:
     - Robot configuration: G1_29Dof_TorsoBase (29 degrees of freedom)
     - Joint position protection ratio: 2.0
     - Camera runs in a separate process for better performance
-    - Motion data with object trajectories is currently not yet available;
-      object-related observations return zeros until data is provided
+    - Interaction deployment does not use object-state policy inputs anymore
+    - The default interaction logdir points to the sitting export
 """
 
 import os
@@ -120,18 +122,25 @@ from instinct_onboard.agents.walk_agent import WalkAgent
 from instinct_onboard.ros_nodes.realsense import UnitreeRsCameraNode
 
 MAIN_LOOP_FREQUENCY_CHECK_INTERVAL = 500
+SITTING_INTERACTION_LOGDIR = "/home/fan/dev3/project-instinct/InstinctLab/logs/instinct_rl/g1_interaction/sitting"
+INTERACTION_REQUIRED_FILES = (
+    "params/env.yaml",
+    "params/agent.yaml",
+    "exported/actor.onnx",
+    "exported/0-depth_image.onnx",
+    "exported/policy_normalizer.npz",
+)
+
+
+def validate_interaction_logdir(logdir: str) -> None:
+    """Fail fast if the interaction sitting export is incomplete."""
+    missing = [os.path.join(logdir, relpath) for relpath in INTERACTION_REQUIRED_FILES if not os.path.exists(os.path.join(logdir, relpath))]
+    if missing:
+        raise FileNotFoundError("Interaction logdir is missing required sitting artifacts: " + ", ".join(missing))
 
 
 class G1InteractionNode(UnitreeRsCameraNode):
-    """ROS2 node for G1 interaction task.
-    
-    This node manages multiple agents for the interaction workflow:
-    - cold_start: Initial pose transition
-    - walk: Basic walking behavior
-    - interaction: Object manipulation with motion reference and depth perception
-    
-    The node handles agent switching based on joystick input and motion completion.
-    """
+    """ROS2 node for G1 interaction task."""
 
     def __init__(
         self,
@@ -397,6 +406,7 @@ class G1InteractionNode(UnitreeRsCameraNode):
 
 def main(args):
     """Main entry point for the G1 interaction node."""
+    validate_interaction_logdir(args.logdir)
     rclpy.init()
 
     node = G1InteractionNode(
@@ -459,27 +469,27 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="G1 Interaction Node - Interaction task with depth perception and object tracking"
+        description="G1 Interaction Node aligned with the sitting interaction export"
     )
     
     # Required arguments
     parser.add_argument(
         "--logdir",
         type=str,
-        required=True,
-        help="Directory to load the interaction agent from (must contain exported/actor.onnx)",
+        help="Directory to load the sitting-aligned interaction agent from",
+        default=SITTING_INTERACTION_LOGDIR,
     )
     parser.add_argument(
         "--walk_logdir",
         type=str,
-        required=True,
         help="Directory to load the walk agent from (must contain exported/actor.onnx)",
+        default="/home/fan/dev3/project-instinct/InstinctLab/logs/instinct_rl/g1_locomotion_flat/20260322_134921_G1Flat_feetAirTime1.00_standStill0.80_actionRate0.40_jointDeviationKnee0.20",
     )
     parser.add_argument(
         "--motion_dir",
         type=str,
-        required=True,
         help="Directory containing motion files (.npz format)",
+        default="/home/fan/dev3/project-instinct/InstinctLab/assets_datasets/interaction/output_npz_29dof_with_object/chair",
     )
     
     # Optional arguments

--- a/scripts/g1_interaction.py
+++ b/scripts/g1_interaction.py
@@ -146,6 +146,8 @@ class G1InteractionNode(UnitreeRsCameraNode):
         self,
         *args,
         motion_vis: bool = False,
+        interaction_startup_step_size: float = 0.2,
+        interaction_kpkd_factor: float = 1.0,
         **kwargs,
     ):
         """Initialize the G1 interaction node.
@@ -160,6 +162,9 @@ class G1InteractionNode(UnitreeRsCameraNode):
         self.current_agent_name: str | None = None
         self.motion_vis = motion_vis
         self._motion_file_list = []  # List of available motion files
+        self.interaction_startup_step_size = interaction_startup_step_size
+        self.interaction_kpkd_factor = interaction_kpkd_factor
+        self.interaction_cold_start_agent = None
 
     def register_agent(self, name: str, agent):
         """Register an agent with the node.
@@ -287,6 +292,28 @@ class G1InteractionNode(UnitreeRsCameraNode):
                 self.get_logger().info("RIGHT button pressed, switching to interaction agent.")
                 self._switch_to_interaction_motion(3)
 
+        # Handle interaction cold start agent
+        elif self.current_agent_name == "interaction_cold_start":
+            if self.joy_stick_data.L1 and "walk" in self.available_agents:
+                self.get_logger().info("L1 button pressed, aborting interaction cold start and switching to walk agent.")
+                self.interaction_cold_start_agent = None
+                self.current_agent_name = "walk"
+                self.available_agents[self.current_agent_name].reset()
+            else:
+                action, done = self.interaction_cold_start_agent.step()
+                self.send_action(
+                    action,
+                    self.interaction_cold_start_agent.action_offset,
+                    self.interaction_cold_start_agent.action_scale,
+                    self.interaction_cold_start_agent.p_gains,
+                    self.interaction_cold_start_agent.d_gains,
+                )
+                if done:
+                    self.get_logger().info("Interaction cold start done, switching to interaction policy.")
+                    self.clear_action_buffer()
+                    self.interaction_cold_start_agent = None
+                    self.current_agent_name = "interaction"
+
         # Handle interaction agent
         elif self.current_agent_name == "interaction":
             action, done = self.available_agents[self.current_agent_name].step()
@@ -357,8 +384,13 @@ class G1InteractionNode(UnitreeRsCameraNode):
                 f"Motion index {motion_index} out of range, using default motion"
             )
         
-        self.current_agent_name = "interaction"
-        self.available_agents[self.current_agent_name].reset(motion_name)
+        interaction_agent = self.available_agents["interaction"]
+        interaction_agent.reset(motion_name)
+        self.interaction_cold_start_agent = interaction_agent.get_cold_start_agent(
+            startup_step_size=self.interaction_startup_step_size,
+            kpkd_factor=self.interaction_kpkd_factor,
+        )
+        self.current_agent_name = "interaction_cold_start"
 
     def vis_callback(self):
         """Visualization callback for publishing motion sequence as JointState.
@@ -416,6 +448,8 @@ def main(args):
         joint_pos_protect_ratio=2.0,
         robot_class_name="G1_29Dof_TorsoBase",
         motion_vis=args.motion_vis,
+        interaction_startup_step_size=args.startup_step_size,
+        interaction_kpkd_factor=args.kpkd_factor,
         dryrun=not args.nodryrun,
     )
 

--- a/scripts/g1_interaction.py
+++ b/scripts/g1_interaction.py
@@ -411,7 +411,7 @@ class G1InteractionNode(UnitreeRsCameraNode):
         # Publish JointState for target joints
         js = JointState()
         js.header.stamp = self.get_clock().now().to_msg()
-        js.name = self.sim_joint_names
+        js.name = getattr(agent, "policy_joint_names", self.sim_joint_names)
         joint_pos = agent.motion_data.joint_pos[cursor]
         joint_vel = agent.motion_data.joint_vel[cursor]
         js.position = joint_pos.tolist()


### PR DESCRIPTION
## Summary

This PR fixes several bugs found during code review and improves documentation clarity.

## Bug Fixes

### 1. Missing f-string in deprecation warning (`agents/base.py`)

The `_parse_generated_commands` method printed a raw string instead of an f-string, so `{command_name}` was never interpolated and the warning message was always printed literally with the placeholder text.

```python
# Before (broken)
print("Warning: '_get_{command_name}_obs' for command {command_name} shall be deprecated...")

# After
print(f"Warning: '_get_{command_name}_obs' for command {command_name} shall be deprecated...")
```

### 2. NaN check after buffer write in `send_action` (`ros_nodes/base.py`)

The NaN guard was placed *after* writing to `self.action` and publishing to the action topic. If the action contained NaN, `self.action` would be poisoned and `_get_last_action_obs()` would return NaN in the next step, causing cascading NaN propagation.

Fix: move the NaN check to the top of `send_action`, before any writes.

### 3. NaN check after motor buffer write in `_publish_motor_cmd` (`ros_nodes/unitree.py`)

Similarly, the NaN guard in `_publish_motor_cmd` was placed after the loop that writes `target_joint_pos` into `low_cmd_buffer`. If NaN was detected, the buffer would already be corrupted.

Fix: move the NaN check before the write loop.

### 4. Misleading comment in `get_cold_start_agent` (`agents/tracking_agent.py`)

The inline comments on the `action_scale` and `action_offset` arguments were swapped, incorrectly describing what each parameter does.

## Documentation

### README: clarify `unitree_hg` / `unitree_go` installation

The previous instruction only mentioned "install `unitree_hg` and `unitree_go`" without explaining how. These packages come from building [unitree_ros2](https://github.com/unitreerobotics/unitree_ros2) and sourcing its workspace. Without this step, Python will raise `ModuleNotFoundError` at import time.